### PR TITLE
chore: add new global workflow for slack and twitter notifications

### DIFF
--- a/.github/workflows/issues_prs_notifications.yml
+++ b/.github/workflows/issues_prs_notifications.yml
@@ -9,6 +9,7 @@ on:
     pull_request:
         types:
             - opened
+            - edited
 
 jobs:
 
@@ -25,7 +26,7 @@ jobs:
             - name: Send info about issue
               uses: rtCamp/action-slack-notify@v2
               env:
-                SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_NEWISSUEPR }}
+                SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
                 SLACK_TITLE: 🐛 New Issue 🐛
                 SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
                 MSG_MINIMAL: true
@@ -43,7 +44,7 @@ jobs:
             - name: Send info about pull request
               uses: rtCamp/action-slack-notify@v2
               env:
-                SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_NEWISSUEPR }}
+                SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
                 SLACK_TITLE: 💪 New Pull Request 💪
                 SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
                 MSG_MINIMAL: true

--- a/.github/workflows/issues_prs_notifications.yml
+++ b/.github/workflows/issues_prs_notifications.yml
@@ -1,0 +1,49 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+name: 'Notify slack that there is a new issue or a PR'
+
+on:
+    issues:
+        types:
+            - opened
+    pull_request:
+        types:
+            - opened
+
+jobs:
+
+    issue:
+        if: github.event_name == 'issues' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+        name: Slack - notify on every new issue
+        runs-on: ubuntu-latest
+        steps:
+            - name: Convert markdown to slack markdown for issue
+              uses: LoveToKnow/slackify-markdown-action@v1.0.0
+              id: issuemarkdown
+              with:
+                text: "[${{github.event.issue.title}}](${{github.event.issue.html_url}}) \n ${{github.event.issue.body}}"
+            - name: Send info about issue
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_NEWISSUEPR }}
+                SLACK_TITLE: 🐛 New Issue 🐛
+                SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+                MSG_MINIMAL: true
+
+    pull_request:
+        if: github.event_name == 'pull_request' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+        name: Slack - notify on every new pull request
+        runs-on: ubuntu-latest
+        steps:
+            - name: Convert markdown to slack markdown for pull request
+              uses: LoveToKnow/slackify-markdown-action@v1.0.0
+              id: prmarkdown
+              with:
+                text: "[${{github.event.pull_request.title}}](${{github.event.pull_request.html_url}}) \n ${{github.event.pull_request.body}}"
+            - name: Send info about pull request
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                SLACK_WEBHOOK: ${{ secrets.SLACK_GITHUB_NEWISSUEPR }}
+                SLACK_TITLE: 💪 New Pull Request 💪
+                SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+                MSG_MINIMAL: true

--- a/.github/workflows/release_announcements.yml
+++ b/.github/workflows/release_announcements.yml
@@ -1,0 +1,76 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+name: 'Announce releases in different channels'
+
+on: 
+  release:
+    types: 
+      - published
+
+jobs:
+
+  slack:
+    name: Slack - notify on every release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Convert markdown to slack markdown for issue
+        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        id: markdown
+        with:
+            text: "[${{github.event.release.tag_name}}](${{github.event.release.html_url}}) \n ${{ github.event.release.body }}"
+      - name: Send info about release to Slack
+        uses: rtCamp/action-slack-notify@v2
+        env:
+            SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASES }}
+            SLACK_TITLE: Release ${{github.event.release.tag_name}} for ${{github.repository}} is out in the wild 😱💪🍾🎂
+            SLACK_MESSAGE: ${{steps.markdown.outputs.text}}
+            MSG_MINIMAL: true
+
+  twitter:
+    name: Twitter - notify on minor and major releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Get version of last and previous release
+        uses: actions/github-script@v3
+        id: versions
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const query = `query($owner:String!, $name:String!) {
+              repository(owner:$owner, name:$name){
+                releases(first: 2, orderBy: {field: CREATED_AT, direction: DESC}) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo
+            };
+            const { repository: { releases: { nodes } } } = await github.graphql(query, variables);
+            core.setOutput('lastver', nodes[0].name);
+            // In case of first release in the package, there is no such thing as previous error, so we set info about previous version only once we have it
+            // We should tweet about the release no matter of the type as it is initial release
+            if (nodes.length != 1) core.setOutput('previousver', nodes[1].name);
+      - name: Identify release type
+        id: releasetype
+        # if previousver is not provided then this steps just logs information about missing version, no errors
+        run: echo "::set-output name=type::$(npx -q -p semver-diff-cli semver-diff ${{steps.versions.outputs.previousver}} ${{steps.versions.outputs.lastver}})"
+      - name: Get name of the person that is behind the newly released version
+        id: author
+        run: echo "::set-output name=name::$(git log -1 --pretty=format:'%an')"
+      - name: Publish information about the release to Twitter # tweet only if detected version change is not a patch
+        # tweet goes out even if the type is not major or minor but "You need provide version number to compare."
+        # it is ok, it just means we did not identify previous version as we are tweeting out information about the release for the first time
+        if: steps.releasetype.outputs.type != 'null' && steps.releasetype.outputs.type != 'patch' # null means that versions are the same
+        uses: m1ner79/Github-Twittction@v1.0.1
+        with:
+          twitter_status: "Release ${{github.event.release.tag_name}} for ${{github.repository}} is out in the wild 😱💪🍾🎂\n\nThank you for the contribution ${{ steps.author.outputs.name }} ${{github.event.release.html_url}}"
+          twitter_consumer_key: ${{ secrets.TWITTER_CONSUMER_KEY }} 
+          twitter_consumer_secret: ${{ secrets.TWITTER_CONSUMER_SECRET }} 
+          twitter_access_token_key: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }} 
+          twitter_access_token_secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- New workflow that will be added to all repositories for sending notifications to slack on new PRs and Issues
  - separate channel #github-new-issues-prs
  - dependabot and asyncapi bot filtered out
  - example messages you can already see in #github-new-issues-prs channel
- New workflow responsible for releases announcements
 - all releases from all repos will go to slack to #github-releases (example already there)
 - Twitter (as agreed, only for minor and major) will be integrated into all repos. How we check if there is a new release, and what type of release is it was improved as package.json or npm scripts are no longer needed. This solution works now with all types of repos that do GitHub Releases

as a result of this PR:
- we should remove github-activity channel and app integration  
- before merging I need to adjust release workflow for HTML template and parser as we already have Twitter there