### PR TITLE
ci: add generic version bump and pr testing and relese workflows for nodejs

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating global workflows
-        uses: derberg/global-workflows-support@v0.0.7
+        uses: derberg/global-workflows-support@v0.0.8
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           # this action will not replicate to other repos workflows listed here

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
+        run: bash test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -1,7 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 #It does magic only if there is package.json file in the root of the project
-name: PR testing if Node project
+name: PR testing - if Node project
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ jobs:
           node-version: 14
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        run: npm install
+        run: npm install --loglevel verbose
       - if: steps.packagejson.outputs.exists == 'true'
         name: Test
         run: npm test

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 14
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        run: npm ci
+        run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
         name: Test
         run: npm test

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo ""::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -1,3 +1,6 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+#It does magic only if there is package.json file in the root of the project
 name: PR testing if Node project
 
 on:
@@ -17,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
+        run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -36,3 +36,6 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'
         name: Run linter
         run: npm run lint
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Run release assets generation to make sure PR does not break it
+        run: npm run generate:assets

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -17,7 +17,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: bash test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
+        shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -1,0 +1,34 @@
+name: PR testing if Node project
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if Node.js project and has package.json
+        id: packagejson
+        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Install dependencies
+        run: npm ci
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Test
+        run: npm test
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Run linter
+        run: npm run lint

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo ""::set-output name=exists::false"
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -1,7 +1,4 @@
-#This action is centrally managed in https://github.com/asyncapi/.github/
-#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
-#It does magic only if there is package.json file in the root of the project
-name: Release in Node project
+name: Release - if Node project
 
 on:
   push:

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -1,3 +1,6 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+#It does magic only if there is package.json file in the root of the project
 name: Release - if Node project
 
 on:

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -1,7 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 #It does magic only if there is package.json file in the root of the project
-name: Release
+name: Release in Node project
 
 on:
   push:

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -18,7 +18,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: bash test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
+        shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if Node.js project and has package.json
+        id: packagejson
+        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Install dependencies
+        run: npm ci
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Run test
+        run: npm test
+
+  release:
+    needs: test
+    name: Publish to NPM and GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if Node.js project and has package.json
+        id: packagejson
+        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Install dependencies
+        run: npm ci
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Release to NPM and GitHub
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_AUTHOR_NAME: asyncapi-bot
+          GIT_AUTHOR_EMAIL: info@asyncapi.io
+          GIT_COMMITTER_NAME: asyncapi-bot
+          GIT_COMMITTER_EMAIL: info@asyncapi.io
+        run: npm run release

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -1,3 +1,6 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+#It does magic only if there is package.json file in the root of the project
 name: Release
 
 on:
@@ -18,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
+        run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
@@ -41,7 +44,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
+        run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
+        run: bash test -e ./package.json && "echo ::set-output name=exists::true" || "echo ::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 14
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        run: npm ci
+        run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
         name: Run test
         run: npm test
@@ -52,7 +52,7 @@ jobs:
           node-version: 14
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        run: npm ci
+        run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
         name: Release to NPM and GitHub
         id: release

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -1,7 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 #It does magic only if there is package.json file in the root of the project
-name: 'Version bump after release in Node.js projects'
+name: 'Version bump if Node.js projects'
 
 on: 
   release:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   version_bump:
-    name: Bump version in package.json if it exists
+    name: Generate assets and bump
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -24,8 +24,8 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'  
         name: Bump version in package.json
         # There is no need to substract "v" from the tag as version script handles it
-        # We make sure here no tags are added by default as they are already added by release workflow
-        # --allow-same-version is set in case someone forgot and updated package.json manually and we want to avoide this action to fail and raise confusion
+        # When adding "bump:version" script in package.json, make sure no tags are added by default (--no-git-tag-version) as they are already added by release workflow
+        # When adding "bump:version" script in package.json, make sure --allow-same-version is set in case someone forgot and updated package.json manually and we want to avoide this action to fail and raise confusion
         run: VERSION=${{github.event.release.tag_name}} npm run bump:version
       - if: steps.packagejson.outputs.exists == 'true'
         name: Create Pull Request with updated asset files including package.json

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -1,7 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 #It does magic only if there is package.json file in the root of the project
-name: Version bump if Node project
+name: Version bump - if Node.js project
 
 on: 
   release:
@@ -15,9 +15,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: master
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Install dependencies
+        run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
         name: Assets generation
         run: npm run generate:assets

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -1,7 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 #It does magic only if there is package.json file in the root of the project
-name: 'Version bump if Node.js projects'
+name: Version bump if Node project
 
 on: 
   release:

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
+        run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Assets generation
         run: npm run generate:assets

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json
         id: packagejson
-        run: test -e ./package.json && "::set-output name=exists::true" || "::set-output name=exists::false"
+        run: test -e ./package.json && echo ::set-output name=exists::true || echo ::set-output name=exists::false
       - if: steps.packagejson.outputs.exists == 'true'
         name: Assets generation
         run: npm run generate:assets

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,14 +20,13 @@ jobs:
         run: test -e ./package.json && "::set-output name=exists::true" || "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
         name: Assets generation
-        run: npm generate:assets
+        run: npm run generate:assets
       - if: steps.packagejson.outputs.exists == 'true'  
         name: Bump version in package.json
         # There is no need to substract "v" from the tag as version script handles it
         # We make sure here no tags are added by default as they are already added by release workflow
         # --allow-same-version is set in case someone forgot and updated package.json manually and we want to avoide this action to fail and raise confusion
-        # run: npm --no-git-tag-version --allow-same-version version ${{github.event.release.tag_name}}
-        run: VERSION=${{github.event.release.tag_name}} npm bump:version
+        run: VERSION=${{github.event.release.tag_name}} npm run bump:version
       - if: steps.packagejson.outputs.exists == 'true'
         name: Create Pull Request with updated asset files including package.json
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,41 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+#It does magic only if there is package.json file in the root of the project
+name: 'Version bump after release in Node.js projects'
+
+on: 
+  release:
+    types: 
+      - published
+
+jobs:
+  version_bump:
+    name: Bump version in package.json if it exists
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Check if Node.js project and has package.json
+        id: packagejson
+        run: test -e ./package.json && "::set-output name=exists::true" || "::set-output name=exists::false"
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Assets generation
+        run: npm generate:assets
+      - if: steps.packagejson.outputs.exists == 'true'  
+        name: Bump version in package.json
+        # There is no need to substract "v" from the tag as version script handles it
+        # We make sure here no tags are added by default as they are already added by release workflow
+        # --allow-same-version is set in case someone forgot and updated package.json manually and we want to avoide this action to fail and raise confusion
+        # run: npm --no-git-tag-version --allow-same-version version ${{github.event.release.tag_name}}
+        run: VERSION=${{github.event.release.tag_name}} npm bump:version
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Create Pull Request with updated asset files including package.json
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: 'chore(release): ${{github.event.release.tag_name}}'
+          committer: asyncapi-bot <info@asyncapi.io>
+          author: asyncapi-bot <info@asyncapi.io>
+          title: 'chore(release): ${{github.event.release.tag_name}}'
+          body: 'Version bump in package.json for release [${{github.event.release.tag_name}}](${{github.event.release.html_url}})'
+          branch: version-bump/${{github.event.release.tag_name}} 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- these are workflows that will be populated to all repos, even non-nodejs, but will only work if `package.json` is in the root

**version bump**
- the biggest advantage of this one is that PR creation action that we depend on will be updated globally only in this workflow (easier to fix issues like https://github.com/asyncapi/markdown-template/issues/55), and will not be an integral part of individual release workflows
- we will have to maintain 2 scripts in every nodejs project:
  - `generate:assets` that will run scripts like the ones about generating docs. toc in readme or types
  - `bump:version` that will run scripts to bump version of the package in package.json

**pr testing**
- changing what nodejs version we are testing in all repos will be as simple as updating just this one single workflow
- we introduce matrix testing on not only linux but also macos and windows

**release workflow**
This is what I'm happy with the most, that was not my intention at the beginning but after testing it with React component that had the most complicated release workflow I'm now sure that we can have a simple generic release workflow that can be easily extended per repo with the approach we did in react https://github.com/asyncapi/asyncapi-react/blob/master/.github/workflows/release-wc-and-playground.yml


**Related issue(s)**
See also https://github.com/asyncapi/asyncapi/issues/423