### PR TITLE
ci: add monitoring if there are not merged PRs that should be automerged

### DIFF
--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -1,0 +1,63 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+name: 'Notify on failing automerge'
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  identify-orphans:
+    name: Find orphans and notify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get list of orphans
+        uses: actions/github-script@v3
+        id: orphans
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const query = `query($owner:String!, $name:String!) {
+              repository(owner:$owner, name:$name){
+                pullRequests(first: 100){
+                  nodes{
+                    title
+                    url
+                    author {
+                      resourcePath
+                    }
+                    state
+                  }
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo
+            };
+            const { repository: { pullRequests: { nodes } } } = await github.graphql(query, variables);
+
+            let orphans = nodes.filter((pr)=> pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'))
+
+            if (orphans.length) {
+              core.setOutput('found', 'true');
+              //Yes, this is very naive approach to assume there is just one PR causing issues, there can be a case that more PRs are affected the same day
+              //The thing is that handling multiple PRs will increase a complexity in this PR that in my opinion we should avoid
+              //The other PRs will be reported the next day the action runs, or person that checks first url will notice the other ones
+              core.setOutput('url', orphans[0].url);
+              core.setOutput('title', orphans[0].title);
+            }
+      - if: steps.orphans.outputs.found == 'true'
+        name: Convert markdown to slack markdown
+        uses: LoveToKnow/slackify-markdown-action@v1.0.0
+        id: issuemarkdown
+        with:
+          text: "-> [${{steps.orphans.outputs.title}}](${{steps.orphans.outputs.url}})"
+      - if: steps.orphans.outputs.found == 'true'
+        name: Send info about orphan to slack
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
+          SLACK_TITLE: 🚨 Not merged PR that should be automerged 🚨
+          SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+          MSG_MINIMAL: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- As a result of this PR, all repos will get a workflow that runs once a day at midnight and reports if there are any PRs from asyncapi-bot or dependabot that are not merged, while they should

This is what message will show up in #github-new-issues-prs channel
<img width="557" alt="Screenshot 2021-01-19 at 19 02 22" src="https://user-images.githubusercontent.com/6995927/105074965-66675700-5a89-11eb-8306-a91a096a75a3.png">

Why we need this? @jonaslagoni found this https://github.com/asyncapi/raml-dt-schema-parser/pull/25 and we agreed that next time we should definitely learn about those cases in an automated way. This PR is a proposal from my side on how we can do this
