### PR TITLE
ci: add pull request title linter workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,21 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+name: Lint PR title
+
+on:
+
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+jobs:
+
+    lint:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: amannn/action-semantic-pull-request@v3.2.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          subjectPattern: ^(?![a-z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" should start with an uppercase character.

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -16,6 +16,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
-          subjectPattern: ^(?![a-z]).+$
+          subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}" should start with an uppercase character.
+            The subject "{subject}" found in the pull request title "{title}" should start with a lowercase character.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- We discussed we need PR title linter before we can think of automating PR merges through `/merge` comment, instead of asking people to click merge button
- My proposal is to use `amannn/action-semantic-pull-request` as it is the only action that also gives an option to validate the uppercase/lowercase of the subject. I contributed there last week a way to provide a custom error message that explains what went wrong with validation in a more human-friendly manner. 
- yes, we never talked about `should it be uppercase` or `should it be lowercase`. I just noticed I do lowercase always but the majority do uppercase. So let us just stick to one

**Related issue(s)**
See also https://github.com/asyncapi/asyncapi/issues/423