### PR TITLE
ci: add go-pr-testing workflow

### DIFF
--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -1,6 +1,6 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
-#It does magic only if there is package.json file in the root of the project
+#It does magic only if there is go.mod file in the root of the project
 name: PR testing - if Go project
 
 on:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -1,0 +1,51 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+#It does magic only if there is package.json file in the root of the project
+name: PR testing - if Go project
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  lint:
+    if: github.event.pull_request.draft == false
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if Go project and has go.mod
+        id: gomod
+        run: test -e ./go.mod && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
+        shell: bash
+      - if: steps.gomod.outputs.exists == 'true'
+        name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+  
+  test:
+    if: github.event.pull_request.draft == false
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Check if Go project and has go.mod
+        id: gomod
+        run: test -e ./go.mod && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
+        shell: bash
+      - if: steps.gomod.outputs.exists == 'true'
+        name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - if: steps.gomod.outputs.exists == 'true'
+        name: Build
+        run: go build -v ./...
+      - if: steps.gomod.outputs.exists == 'true'
+        name: Test
+        run: go test -v ./...
+ 

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -27,7 +27,8 @@ jobs:
       - if: steps.gomod.outputs.exists == 'true'
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2 # golangci-lint version extracted from go.mod. `latest` if missing.
-        skip-go-installation: true # we wanna control the version of Go in use
+        with:
+          skip-go-installation: true # we wanna control the version of Go in use
   
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -20,10 +20,14 @@ jobs:
         run: test -e ./go.mod && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
       - if: steps.gomod.outputs.exists == 'true'
-        name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        name: Setup Go
+        uses: actions/setup-go@v2.1.3
         with:
-          version: v1.39
+          go-version: 1.16
+      - if: steps.gomod.outputs.exists == 'true'
+        name: golangci-lint
+        uses: golangci/golangci-lint-action@v2 # golangci-lint version extracted from go.mod. `latest` if missing.
+        skip-go-installation: true # we wanna control the version of Go in use
   
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -22,6 +22,8 @@ jobs:
       - if: steps.gomod.outputs.exists == 'true'
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39
   
   test:
     if: github.event.pull_request.draft == false
@@ -39,9 +41,9 @@ jobs:
         shell: bash
       - if: steps.gomod.outputs.exists == 'true'
         name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
       - if: steps.gomod.outputs.exists == 'true'
         name: Build
         run: go build -v ./...


### PR DESCRIPTION
Part of https://github.com/asyncapi/shape-up-process/issues/94
This PR adds a new workflow for **Go** projects. It runs two steps:

- **lint**
  - It runs [golangci-lint](https://golangci-lint.run/) linter, which it is a tool that runs the most common linters for go.
  - Note: The configuration for the linters are up to each repository (via `.golangci.yml` file), however I think it makes sense if we create a repository template for Go projects that contain, among others, that file. I created a [gist](https://gist.github.com/smoya/35720dd325025dc5665a4f86d1849aae) containing all the config we might want to set.
- **test**
  - It ensures the app can be built.
  - It runs tests.

Note: The golangci-lint gh action not only fails the build in case of lint issues but it shows those issues in the PR review as a check runs. 
Example:
![image](https://user-images.githubusercontent.com/1083296/112652771-0d7fba80-8e4e-11eb-821c-72d3ace2c3c9.png)
