### PR TITLE
ci: update autoapprove workflow to v2 and pr target event

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,7 @@
 name: Automerge release bump PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - unlabeled
@@ -17,10 +17,6 @@ on:
   pull_request_review:
     types:
       - submitted
-  check_suite: 
-    types:
-      - completed
-  status: {}
   
 jobs:
 
@@ -29,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Autoapproving
-        uses: hmarr/auto-approve-action@v2.0.0
+        uses: hmarr/auto-approve-action@v2
         if: github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- recently autoapprove workflows were failing and this is the issue https://github.com/hmarr/auto-approve-action/issues/183 that explains what has changed to default GITHUB token