### PR TITLE
ci: allow running global-workflows-support workflow manually

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -3,6 +3,7 @@ name: Global workflow to rule them all
 on:
   push:
       branches: [ master ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -3,7 +3,7 @@ name: Global workflow to rule them all
 on:
   push:
       branches: [ master ]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
 


### PR DESCRIPTION
This PR change allows triggering `global-workflows-support` workflow manually from Github UI. 
More info on https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/