### PR TITLE
ci: exclude parser-api from global workflows

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -21,7 +21,7 @@ jobs:
           # this action will not replicate to other repos workflows listed here
           files_to_ignore: global-workflows-support.yml
           # workflows will not be replicated to repos listed here
-          repos_to_ignore: shape-up-process,marketing,event-gateway
+          repos_to_ignore: shape-up-process,marketing,event-gateway,parser-api
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           # it is both, commit message and PR title


### PR DESCRIPTION
This PR adds https://github.com/asyncapi/parser-api repository to the ignored repositories list so global workflows are not installed.
The reason is that https://github.com/asyncapi/parser-api repository will only contain documentation (at least by now).