### PR TITLE
chore: add training repo to the list of repos to ignore

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -21,7 +21,7 @@ jobs:
           # this action will not replicate to other repos workflows listed here
           files_to_ignore: global-workflows-support.yml
           # workflows will not be replicated to repos listed here
-          repos_to_ignore: shape-up-process,marketing,event-gateway
+          repos_to_ignore: shape-up-process,marketing,event-gateway,training
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           # it is both, commit message and PR title


### PR DESCRIPTION
It adds the `training` repo to the list of repos to ignore.