### PR TITLE
ci: pin to nodejs workflows next and releases branches

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - master
+      - next
+      - '**-release'
 
 jobs:
 

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - master
+      # below lines are not enough to have release supported for these branches
+      # make sure configuration of `semantic-release` package mentiones these branches
       - next
       - '**-release'
 

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -13,10 +13,16 @@ jobs:
     name: Generate assets and bump
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
+      - name: Checkout repository (@latest tag -> master branch)
+        if: "!contains(github.event.release.tag_name, 'next')"
         uses: actions/checkout@v2
         with:
           ref: master
+      - name: Checkout repository (@next tag -> next branch)
+        if: "contains(github.event.release.tag_name, 'next')"
+        uses: actions/checkout@v2
+        with:
+          ref: next
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -13,16 +13,13 @@ jobs:
     name: Generate assets and bump
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository (@latest tag -> master branch)
-        if: "!contains(github.event.release.tag_name, 'next')"
+      - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: master
-      - name: Checkout repository (@next tag -> next branch)
-        if: "contains(github.event.release.tag_name, 'next')"
-        uses: actions/checkout@v2
-        with:
-          ref: next
+          # target branch of release. More info https://docs.github.com/en/rest/reference/repos#releases
+          # in case release is created from release branch then we need to checkout from given branch
+          # if @semantic-release/github is used to publish, the minimum version is 7.2.0 for proper working
+          ref: ${{ github.event.release.target_commitish }}
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Pin `next` and `**-release` branches to `if-nodejs-release` workflows.
- Update `if-nodejs-version-bump` workflow including `next` branch.

`next` branch at the moment is only used in `react-component` repo.