### PR TITLE
ci: enable event-gateway repo

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -21,7 +21,7 @@ jobs:
           # this action will not replicate to other repos workflows listed here
           files_to_ignore: global-workflows-support.yml
           # workflows will not be replicated to repos listed here
-          repos_to_ignore: shape-up-process,marketing,event-gateway,training
+          repos_to_ignore: shape-up-process,marketing,training
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           # it is both, commit message and PR title


### PR DESCRIPTION
Now that the event-gateway repo is gonna have Go code inside, we need to remove it from the ignore list.