### PR TITLE
fix: add more logs to orphan alerts workflow and improve auto-approve

### DIFF
--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -38,7 +38,13 @@ jobs:
             };
             const { repository: { pullRequests: { nodes } } } = await github.graphql(query, variables);
 
-            let orphans = nodes.filter((pr)=> pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'))
+            let orphans = nodes.filter((pr)=> {
+              console.log('PR', pr.url);
+              console.log('State', pr.state);
+              console.log('Author resource path', pr.author.resourcePath);
+              console.log('Is orphan', pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'));
+              return pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot')
+            })
 
             if (orphans.length) {
               core.setOutput('found', 'true');

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Autoapproving
         uses: hmarr/auto-approve-action@v2
-        if: github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        if: github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' || !contains(github.event.pull_request.labels.*.name, 'released')
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Autoapproving
         uses: hmarr/auto-approve-action@v2
-        if: github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' || !contains(github.event.pull_request.labels.*.name, 'released')
+        if: github.actor == ('asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && !contains(github.event.pull_request.labels.*.name, 'released')
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -44,4 +44,4 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           MERGE_RETRIES: "20"
-          MERGE_RETRY_SLEEP: "20000"
+          MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
- add more logs to orphan alerts workflow to figure out why some are not reported. More info: https://github.com/asyncapi/.github/issues/59
- make sure auto-approve job doesn't approve PR that are already merged and released to not confuse community. Resolves https://github.com/asyncapi/.github/issues/58
- I increased autoapprove delay to 30 sec and we will gain around 3min on that workflow. Did it because of https://github.com/asyncapi/.github/issues/58 and tests that are really long-running there and we need to cover that.

One PR with 2 unrelated changes to have just one update PR in all repos, and not 2, one after another. 

