### PR TITLE
feat: introduce bump workflow as global

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -24,8 +24,9 @@ jobs:
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
         name: Bumping latest version of this package in other repositories
-        uses: derberg/org-projects-dependency-manager@v2
+        uses: derberg/custom-dependabot-for-your-github-org@v2
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
+          repos_to_ignore: html-template #this is temporary until react component releases 1.0, then it can be removed

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,31 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#Purpose of this action is to update npm package in libraries that use it. It is like dependabot for asyncapi npm modules only. 
+#It runs in a repo after merge of release commit and searches for other packages that use released package. Every found package gets updated with lates version
+
+name: Bump package version in dependent repos - if Node project
+
+on:
+  #It cannot run on release event as when release is created then version is not yet bumped in package.json
+  #This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - master
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Check if Node.js project and has package.json
+        id: packagejson
+        run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
+      - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
+        name: Bumping latest version of this package in other repositories
+        uses: derberg/org-projects-dependency-manager@v2
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- merge of this PR cause distribution of this workflow in all repositories and overwrite of the following files in the following repos:
   - https://github.com/asyncapi/generator/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/generator-hooks/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/generator-react-sdk/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/modelina/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/raml-dt-schema-parser/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/openapi-schema-parser/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/parser-js/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/generator-filters/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/spec-json-schemas/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/converter-js/blob/master/.github/workflows/bump.yml
   - https://github.com/asyncapi/avro-schema-parser/blob/master/.github/workflows/bump.yml
   - react-component has bump.yaml and not bump.yml so it would not be overwritten + it is not on master branch. @magicmatatjahu can you handle rename in your branch when you will make your next or?
- thanks to making bump global it will be distributed not only to HTML and markdown templates that do not have it (thus no automated bumps in playground) but also all new repos, like diff or optimizer that in future will be used in CLI and Studio
- using v2 of dependency manager so default commit messages are not part of the action thus we do not need to add custom scripts in our projects to get package name and version - simplified workflow description

do you think it is required to go to all repos mentioned above and remove these scripts:
```
    "get:version": "echo $npm_package_version",
    "get:name": "echo $npm_package_name",
```
I kinda do not feel like this is super important, they are not needed but also not harmful, but I'm opened for arguments to go and remove them in all the repositories

**Related issue(s)**
Resolves https://github.com/asyncapi/.github/issues/34