### PR TITLE
fix: improve alerts on orphan bot prs and discussions and use latest bump

### DIFF
--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -37,9 +37,7 @@ jobs:
             };
             const { repository: { pullRequests: { nodes } } } = await github.graphql(query, variables);
 
-            let orphans = nodes.filter((pr)=> {
-              pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'
-            })
+            let orphans = nodes.filter( (pr) => pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot')
 
             if (orphans.length) {
               core.setOutput('found', 'true');

--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -20,14 +20,13 @@ jobs:
           script: |
             const query = `query($owner:String!, $name:String!) {
               repository(owner:$owner, name:$name){
-                pullRequests(first: 100){
+                pullRequests(first: 100, states: OPEN){
                   nodes{
                     title
                     url
                     author {
                       resourcePath
                     }
-                    state
                   }
                 }
               }
@@ -39,11 +38,7 @@ jobs:
             const { repository: { pullRequests: { nodes } } } = await github.graphql(query, variables);
 
             let orphans = nodes.filter((pr)=> {
-              console.log('PR', pr.url);
-              console.log('State', pr.state);
-              console.log('Author resource path', pr.author.resourcePath);
-              console.log('Is orphan', pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'));
-              return pr.state === 'OPEN' && (pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot')
+              pr.author.resourcePath === '/asyncapi-bot' || pr.author.resourcePath === '/apps/dependabot'
             })
 
             if (orphans.length) {

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -24,7 +24,7 @@ jobs:
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
         name: Bumping latest version of this package in other repositories
-        uses: derberg/custom-dependabot-for-your-github-org@v2
+        uses: derberg/npm-dependency-manager-for-your-github-org@v3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot

--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -1,5 +1,7 @@
 #This action is centrally managed in https://github.com/asyncapi/.github/
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#This action notifies community on slack whenever there is a new issue, PR or discussion started in given repository
 name: Notify slack
 
 on:
@@ -9,6 +11,9 @@ on:
 
   pull_request_target:
     types: [opened, reopened, ready_for_review]
+
+  discussion:
+    types: [opened]
 
 jobs:
 
@@ -46,4 +51,22 @@ jobs:
             SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
             SLACK_TITLE: 💪 New Pull Request 💪
             SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+    
+    discussion:
+      if: github.event_name == 'discussion' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+      name: On every new pull request
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown for pull request
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: discussionmarkdown
+          with:
+            text: "[${{github.event.discussion.title}}](${{github.event.discussion.html_url}}) \n ${{github.event.discussion.body}}"
+        - name: Send info about pull request
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
+            SLACK_TITLE: 💬 New Discussion 💬
+            SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
             MSG_MINIMAL: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

## Orphans

There was a problem the workflow that checks daily for unmerged PRs was not always reporting all the PRs. Some PRs were really waiting for ages to be merged.

Reason was that workflow is not paging-proof and in repos that have over 100PRs it could never work. Now GraphQL query pulls only PRs that have state `OPEN`. So now this action is future-proof and we will have to start to worry if fails only when we will have more than 100 open PRs on a repo. I think once that happens we will have many other bigger issues than this 😆 

**Related issue(s)**
Fixes https://github.com/asyncapi/.github/issues/59

## Discussion

Since discussions are out of beta, now GitHub Actions also support it and we should integrate them with our existing workflow that notifies us about every new pr and issue

## Bump workflow

Had to release another version of bump-responsible action, there was a bug fix + there was also a legal problem I had with GitHub because old name of action had "dependabot" in it 🤷🏼 , now it is called `npm-dependency-manager-for-your-github-org`/