### PR TITLE
ci: update stale workflow to ignore specific labels

### DIFF
--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -38,5 +38,5 @@ jobs:
         days-before-close: 120
         stale-issue-label: stale
         stale-pr-label: stale
-        exempt-issue-label: keep-open
-        exempt-pr-label: keep-open
+        exempt-issue-labels: keep-open
+        exempt-pr-labels: keep-open


### PR DESCRIPTION
unfortunately, I did not notice that new version of the Stale action changed a bit the config property name by adding plural `s` 🤦🏼 

as a result all issues and PRs with `keep-open` were marked by stale action as candidates for closure anyway.

sorry, I will review all the stale bot emails from today and do some cleanup of those at the same time