### PR TITLE
ci: adjust discussion event type for notification workflow

### DIFF
--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -13,7 +13,7 @@ on:
     types: [opened, reopened, ready_for_review]
 
   discussion:
-    types: [opened]
+    types: [created]
 
 jobs:
 


### PR DESCRIPTION
We are not getting any notifications from GitHub Workflow about new discussion because there is such event type as `opened` 🤦🏼 

Docs: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#discussion