### PR TITLE
ci: ignore `infra` repo

### DIFF
--- a/.github/workflows/global-workflows-support.yml
+++ b/.github/workflows/global-workflows-support.yml
@@ -21,7 +21,7 @@ jobs:
           # this action will not replicate to other repos workflows listed here
           files_to_ignore: global-workflows-support.yml
           # workflows will not be replicated to repos listed here
-          repos_to_ignore: shape-up-process,marketing,training,glee-hello-world
+          repos_to_ignore: shape-up-process,marketing,training,glee-hello-world,infra
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           # it is both, commit message and PR title


### PR DESCRIPTION
**Description**

https://github.com/asyncapi/infra don't need to run workflows from org repository. No need for releasing, etc for now. In the future if needed we could add some automations
