### PR TITLE
ci: set git to use LF in test step in nodejs-release workflow

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -21,6 +21,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Check if Node.js project and has package.json


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: set git to use LF in test step in nodejs-release workflow - adding missing first step:

```
      - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
        run: |
          git config --global core.autocrlf false
          git config --global core.eol lf
```

**Related issue(s)**
Failing release process in parser-js - https://github.com/asyncapi/parser-js/runs/4381967909?check_suite_focus=true