### PR TITLE
ci: improve removal of ready-to-merge label only when present

### DIFF
--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -8,7 +8,7 @@ on: issue_comment
 
 jobs:
   parse-comment-and-add-ready: # for handling cases when you want to mark as ready to merge
-    if: github.event.issue.pull_request && github.event.issue.state != 'closed'
+    if: github.event.issue.pull_request && github.event.issue.state != 'closed' && github.actor != 'asyncapi-bot'
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is draft # such info is not available in the context of issue_comment event
@@ -34,7 +34,7 @@ jobs:
             }) 
 
   parse-comment-and-add-block: # for handling cases when you want to mark as do-not-merge
-    if: github.event.issue.pull_request && github.event.issue.state != 'closed'
+    if: github.event.issue.pull_request && github.event.issue.state != 'closed' && github.actor != 'asyncapi-bot'
     runs-on: ubuntu-latest
     steps:
       - name: Add label

--- a/.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml
+++ b/.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml
@@ -20,9 +20,16 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN }}
           script: |
+            const labelToRemove = 'ready-to-merge';
+            const labels = context.payload.pull_request.labels;
+            
+            const isLabelPresent = labels.some(label => label.name === labelToRemove)
+            
+            if(!isLabelPresent) return;
+            
             github.rest.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'ready-to-merge'
+              name: labelToRemove
             }) 


### PR DESCRIPTION
the problem with the current workflow that secures merging from "evil" contributors is that it doesn't check if the `ready-to-merge` label is even there, so it basically fails as it tries to remove a label that is not added to PR