### PR TITLE
ci: include pr number in commit message when automerging

### DIFF
--- a/.github/workflows/automerge-for-humans-merging.yml
+++ b/.github/workflows/automerge-for-humans-merging.yml
@@ -27,6 +27,6 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           MERGE_LABELS: "!do-not-merge,ready-to-merge"
           MERGE_METHOD: "squash"
-          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
           MERGE_RETRIES: "20"
           MERGE_RETRY_SLEEP: "30000"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -54,6 +54,6 @@ jobs:
           GITHUB_LOGIN: asyncapi-bot
           MERGE_LABELS: ""
           MERGE_METHOD: "squash"
-          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
           MERGE_RETRIES: "20"
           MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
As @jonaslagoni noticed [here](https://github.com/asyncapi/modelina/pull/547#issuecomment-1004064050) automerge that I recently introduced do not include the number of the PR that was behind the squashed commit. I fix it with this PR and also fix it for automerging for bots too

I tested it [here](https://github.com/derberg/test-experiment/blob/master/.github/workflows/automerge-for-humans.yml) and result was [this](https://github.com/derberg/test-experiment/commit/7196d94002c445d96d9e416c23acfeef800b5ec0)