### PR TITLE
ci: generate docker image in nodejs-release

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -68,7 +68,7 @@ jobs:
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
-        name: Release to any of NPM, Github, and Docker Hub
+        name: Publish to any of NPM, Github, and Docker Hub
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -47,7 +47,7 @@ jobs:
 
   release:
     needs: test
-    name: Publish to NPM and GitHub
+    name: Publish to NPM/DockerHub and GitHub
     runs-on: ubuntu-latest
     steps:
       - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
@@ -68,11 +68,16 @@ jobs:
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
-        name: Release to NPM and GitHub
+        name: Build Docker Image (if script exists)
+        run: npm run generate:docker --if-present
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Release to NPM/DockerHub and GitHub
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           GIT_AUTHOR_NAME: asyncapi-bot
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -68,10 +68,7 @@ jobs:
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
-        name: Build Docker Image (if script exists)
-        run: npm run generate:docker --if-present
-      - if: steps.packagejson.outputs.exists == 'true'
-        name: Release to NPM/DockerHub and GitHub
+        name: Publish to any of NPM, Github, and Docker Hub
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -47,7 +47,7 @@ jobs:
 
   release:
     needs: test
-    name: Publish to NPM/DockerHub and GitHub
+    name: Publish to any of NPM, Github, and Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Set git to use LF #to once and for all finish neverending fight between Unix and Windows
@@ -68,7 +68,7 @@ jobs:
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
-        name: Publish to any of NPM, Github, and Docker Hub
+        name: Release to any of NPM, Github, and Docker Hub
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Generate docker image in `nodejs-release`:
- add needed envs to push Docker image to DockerHub

If someone want to release docker image have to install `@semantic-release-plus/docker` package in the project and add needed config to the `semantic-release` config. Also need to define Docker Image's build script in the `release` script. Example PR: https://github.com/asyncapi/server-api/pull/24

**Related issue(s)**
Part of https://github.com/asyncapi/server-api/pull/24