### PR TITLE
fix: include all semantic-release default branches for the release workflow + fix Genie

### DIFF
--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create_help_comment_pr:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/help' && github.actor != 'asyncapi-bot') 
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1
@@ -26,7 +26,7 @@ jobs:
             - `/ready-to-merge` or `/rtm` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
             - `/do-not-merge` or `/dnm` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
   create_help_comment_issue:
-    if: !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot'
+    if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create_help_comment_pr:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/help' && github.actor != 'asyncapi-bot') 
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1
@@ -26,7 +26,7 @@ jobs:
             - `/ready-to-merge` or `/rtm` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
             - `/do-not-merge` or `/dnm` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
   create_help_comment_issue:
-    if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot'}}
+    if: !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create_help_comment_pr:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/help' && github.actor != 'asyncapi-bot') 
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/help' && github.actor != 'asyncapi-bot') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   create_help_comment_pr:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/help' && github.actor != 'asyncapi-bot') }}
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-create-comment@v1

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -10,7 +10,10 @@ on:
       # below lines are not enough to have release supported for these branches
       # make sure configuration of `semantic-release` package mentiones these branches
       - next
-      - '**-release'
+      - next-major
+      - beta
+      - alpha
+      - '**-release' # custom
 
 jobs:
 


### PR DESCRIPTION
**Description**

This PR adds all the default semantic-release branches to the release workflow for node apps.
See [semantic-release docs](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches).

This PR will also make Genie behave properly, who has been offering help randomly to people that didn't ask for it 😅 .

**Related issue(s)**
Relates to https://github.com/asyncapi/parser-js/pull/442#discussion_r783098429