### PR TITLE
ci: fix 'automerge' bug + don't run 'autoupdate' for bot branches

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,5 @@
- # This action is centrally managed in https://github.com/asyncapi/.github/
- # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo.
+# This action is centrally managed in https://github.com/asyncapi/.github/
+# Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo.
 
 name: Automerge release bump PR
 
@@ -19,9 +19,8 @@ on:
       - submitted
 
 jobs:
-
   autoapprove:
-    if: github.event.pull_request.draft == false && (github.event.pull_request.user.login == 'asyncapi-bot' || github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot-preview[bot]') && !contains(github.event.pull_request.labels.*.name, 'released')
+    if: github.event.pull_request.draft == false && (github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]') && !contains(github.event.pull_request.labels.*.name, 'released')
     runs-on: ubuntu-latest
     steps:
       - name: Autoapproving
@@ -39,8 +38,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['autoapproved']
-            }) 
-
+            })
 
   automerge:
     needs: [autoapprove]

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -11,7 +11,12 @@
 name: autoupdate
 
 on:
-  push: {}
+  push:
+    branches-ignore:  
+      - 'version-bump/**'
+      - 'dependabot/**'
+      - 'bot/**'
+      - 'all-contributors/**'
 
 jobs:
   autoupdate:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -2,7 +2,7 @@
 #Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 
 #This workflow is designed to work with:
-# - autoapprove and automerge workflows for dependabot and asyncapibot. 
+# - autoapprove and automerge workflows for dependabot and asyncapibot.
 # - special release branches that we from time to time create in upstream repos. If we open up PRs for them from the very beginning of the release, the release branch will constantly update with new things from the destination branch they are opened against
 
 # It uses GitHub Action that auto-updates pull requests branches, whenever changes are pushed to their destination branch.
@@ -12,16 +12,15 @@ name: autoupdate
 
 on:
   push: {}
-  
-jobs:
 
+jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
       - name: Autoupdating
         uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GH_TOKEN }}'
           PR_FILTER: "labelled"
           PR_LABELS: "autoapproved"
           PR_READY_STATE: "ready_for_review"


### PR DESCRIPTION
### Changes
* Autoupdate branches using AsyncAPI bot instead of Github Actions.
* Check GitHub `event actor` instead of `PR Author` before autoapproving.

Fixes #119 