### PR TITLE
docs: fixing incorrect docs label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,7 +1,7 @@
-name: New Doc 📑 
+name: 📑 Docs
 description: Propose changes and improvements to AsyncAPI Docs.
-labels: "📑 new doc"
-title: "[New Doc 📑]: "
+labels: "📑 docs"
+title: "[📑 Docs]: "
 assignees: alequetzalli
   - 
 body:


### PR DESCRIPTION
This PR addresses a mistake I made in the `docs` label for the `docs issue template.` I had originally used a label of `new doc 📄` and also named the `.yml` template as `new doc`. 

This is incorrect since not all Docs issues opened will necessarily be for creating a new piece of documentation. Thus, this PR fixes this assumption by renaming the template and fixing mentions therein of `new docs`.