### PR TITLE
ci: ignore testing for bots in certain PRs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -24,7 +24,7 @@ jobs:
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
         name: Bumping latest version of this package in other repositories
-        uses: derberg/npm-dependency-manager-for-your-github-org@v3
+        uses: derberg/npm-dependency-manager-for-your-github-org@v4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -6,10 +6,12 @@ name: PR testing - if Go project
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+env:
+  SHOULD_RUN: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
 
 jobs:
   lint:
-    if: "github.event.pull_request.draft == false && !((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
+    if: ${{ env.SHOULD_RUN }}
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +33,7 @@ jobs:
           skip-go-installation: true # we wanna control the version of Go in use
   
   test:
-    if: github.event.pull_request.draft == false
+    if: ${{ env.SHOULD_RUN }}
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || && github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || && github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -6,12 +6,10 @@ name: PR testing - if Go project
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-env:
-  SHOULD_RUN: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
-
+    
 jobs:
   lint:
-    if: ${{ env.SHOULD_RUN }}
+    if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +31,7 @@ jobs:
           skip-go-installation: true # we wanna control the version of Go in use
   
   test:
-    if: ${{ env.SHOULD_RUN }}
+    if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    if: github.event.pull_request.draft == false
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || && github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || && github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows') || github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
+    if: "github.event.pull_request.draft == false && !(github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):') || github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add'))"
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
**Description**

- skip testing for `allcontributors` and `asyncapi-bot` in certain PR types.

**Related issue(s)**
fixes #116 