### PR TITLE
ci: new workflow to notify TSC members in slack

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   bump:
+    if: startsWith(github.event.commits[0].message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -22,7 +23,7 @@ jobs:
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
-      - if: steps.packagejson.outputs.exists == 'true' && startsWith(github.event.commits[0].message, 'chore(release):')
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Bumping latest version of this package in other repositories
         uses: derberg/npm-dependency-manager-for-your-github-org@v4
         with:

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -1,0 +1,142 @@
+#This action is centrally managed in https://github.com/asyncapi/.github/
+#Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+#This action notifies community on slack whenever there is a new issue, PR or discussion started in given repository
+name: Notify slack whenever TSC members are mentioned in GitHub
+
+on:
+    issue_comment:
+      types: 
+        - created
+        - edited
+        
+    discussion_comment:
+      types: 
+        - created
+        - edited
+        
+    issues:
+      types:
+        - opened
+        - reopened
+
+    pull_request_target:
+      types: 
+        - opened
+        - reopened
+        - ready_for_review
+
+    discussion:
+      types: 
+        - created
+        - edited
+
+jobs:
+
+    issue:
+      if: github.event_name == 'issues' && contains(github.event.issue.body, '@asyncapi/tsc_members')
+      name: On every new issue
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: issuemarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.issue.html_url}}) \n ${{github.event.issue.body}}"
+        - name: Send info about issue
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New issue that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    pull_request:
+      if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@asyncapi/tsc_members')
+      name: On every new pull request
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: prmarkdown
+          with:
+            text: "[${{github.event.pull_request.title}}](${{github.event.pull_request.html_url}}) \n ${{github.event.pull_request.body}}"
+        - name: Send info about pull request
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New PR that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+    
+    discussion:
+      if: github.event_name == 'discussion' && contains(github.event.discussion.body, '@asyncapi/tsc_members')
+      name: On every new discussion
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: discussionmarkdown
+          with:
+            text: "[${{github.event.discussion.title}}](${{github.event.discussion.html_url}}) \n ${{github.event.discussion.body}}"
+        - name: Send info about pull request
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New discussion that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    issue_comment:
+      if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members') }}
+      name: On every new comment in issue
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: issuemarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about issue comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing issue that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    pr_comment:
+      if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')
+      name: On every new comment in pr
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: prmarkdown
+          with:
+            text: "[${{github.event.issue.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about PR comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing PR that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
+            MSG_MINIMAL: true
+
+    discussion_comment:
+      if: github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@asyncapi/tsc_members')
+      name: On every new comment in discussion
+      runs-on: ubuntu-latest
+      steps:
+        - name: Convert markdown to slack markdown
+          uses: LoveToKnow/slackify-markdown-action@v1.0.0
+          id: discussionmarkdown
+          with:
+            text: "[${{github.event.discussion.title}}](${{github.event.comment.html_url}}) \n ${{github.event.comment.body}}"
+        - name: Send info about discussion comment
+          uses: rtCamp/action-slack-notify@v2
+          env:
+            SLACK_WEBHOOK: ${{secrets.SLACK_TSC_MEMBERS_NOTIFY}}
+            SLACK_TITLE: 🆘 New comment under existing discussion that requires TSC Members attention 🆘
+            SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
+            MSG_MINIMAL: true


### PR DESCRIPTION
This workflow throws a message in a dedicated channel when there is a mention of the GitHub team that groups all technical steering committee members:
- new discussion, issue or PR that mentions the team
- new or edited comment in issue or PR  that mentions the team (message links back to the comment)
- new comment in discussion and new comment/reply to a comment in discussion (message links back to the comment)
- reopened issue or PR that mentions the team

Because of `if` condition in the job, and not steps, workflow is skipped if TSC members are not mentioned

I tested this workflow in new channel `95_bot-tsc-members-mentioned`. Below you can see example messages that were triggered from my [test repo](https://github.com/derberg/test-experiment/actions/runs/1807131912).

![Screenshot 2022-02-07 at 16 07 26](https://user-images.githubusercontent.com/6995927/152814441-a84519cf-ff61-4fd8-b820-e9abe4342b3d.png)

See also https://github.com/asyncapi/community/issues/253
This PR provides notifications to slack only for mentions.

Once we have a voting process facilitated, and we know how to do it, we will need to extend this workflow with new job that triggers a slightly different message, `@channel` with call for voting