### PR TITLE
ci: use custom bot to approve automated PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Autoapproving
         uses: hmarr/auto-approve-action@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.GH_TOKEN_BOT_EVE }}"
 
       - name: Label autoapproved
         uses: actions/github-script@v5

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,8 @@ on:
       - synchronize
 
 jobs:
-  autoapprove:
+  autoapprove-for-bot:
+    name: Autoapprove PR comming from a bot
     if: >
       contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]"]'), github.event.pull_request.user.login) &&
       contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]"]'), github.actor) &&
@@ -34,8 +35,9 @@ jobs:
               labels: ['autoapproved']
             })
 
-  automerge:
-    needs: [autoapprove]
+  automerge-for-bot:
+    name: Automerge PR autoapproved by a bot
+    needs: [autoapprove-for-bot]
     runs-on: ubuntu-latest
     steps:
       - name: Automerging

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -19,7 +19,8 @@ on:
       - 'all-contributors/**'
 
 jobs:
-  autoupdate:
+  autoupdate-for-bot:
+    name: Autoupdate autoapproved PR created in the upstream
     runs-on: ubuntu-latest
     steps:
       - name: Autoupdating

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -14,7 +14,8 @@ on:
       - master
 
 jobs:
-  bump:
+  bump-in-dependent-projects:
+    name: Bump this package in repositories that depend on it
     if: startsWith(github.event.commits[0].message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -8,8 +8,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     
 jobs:
-  lint:
-    name: lint
+  lint-go-pr:
+    name: Lint Go PR
     runs-on: ubuntu-latest
     steps:
       - if: "github.event.pull_request.draft == false &&!((github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'ci: update global workflows')) || (github.actor == 'asyncapi-bot' && startsWith(github.event.pull_request.title, 'chore(release):')) || (github.actor == 'allcontributors' && startsWith(github.event.pull_request.title, 'docs: add')))"
@@ -35,8 +35,8 @@ jobs:
         with:
           skip-go-installation: true # we wanna control the version of Go in use
   
-  test:
-    name: ${{ matrix.os }}
+  test-go-pr:
+    name: Test Go PR - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -8,8 +8,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
-  test:
-    name: ${{ matrix.os }}
+  test-nodejs-pr:
+    name: Test NodeJS PR - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
 
-  test:
-    name: Test on ${{ matrix.os }}
+  test-nodejs:
+    name: Test NodeJS release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
         run: npm test
 
   release:
-    needs: test
+    needs: [test-nodejs]
     name: Publish to any of NPM, Github, and Docker Hub
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   version_bump:
-    name: Generate assets and bump
+    name: Generate assets and bump NodeJS
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -19,7 +19,7 @@ jobs:
 
     issue:
       if: github.event_name == 'issues' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-      name: On every new issue
+      name: Notify slack on every new issue
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown for issue
@@ -37,7 +37,7 @@ jobs:
 
     pull_request:
       if: github.event_name == 'pull_request_target' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-      name: On every new pull request
+      name: Notify slack on every new pull request
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown for pull request
@@ -55,7 +55,7 @@ jobs:
     
     discussion:
       if: github.event_name == 'discussion' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-      name: On every new pull request
+      name: Notify slack on every new pull request
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown for pull request

--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -31,7 +31,7 @@ jobs:
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
-            SLACK_TITLE: 🐛 New Issue 🐛
+            SLACK_TITLE: 🐛 New Issue in ${{github.repository}} 🐛
             SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
             MSG_MINIMAL: true
 
@@ -49,7 +49,7 @@ jobs:
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
-            SLACK_TITLE: 💪 New Pull Request 💪
+            SLACK_TITLE: 💪 New Pull Request in ${{github.repository}} 💪
             SLACK_MESSAGE: ${{steps.prmarkdown.outputs.text}}
             MSG_MINIMAL: true
     
@@ -67,6 +67,6 @@ jobs:
           uses: rtCamp/action-slack-notify@v2
           env:
             SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
-            SLACK_TITLE: 💬 New Discussion 💬
+            SLACK_TITLE: 💬 New Discussion in ${{github.repository}} 💬
             SLACK_MESSAGE: ${{steps.discussionmarkdown.outputs.text}}
             MSG_MINIMAL: true

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -8,7 +8,8 @@ on:
     types: [opened, reopened, synchronize, edited, ready_for_review]
 
 jobs:
-  lint:
+  lint-pr-title:
+    name: Lint PR title
     runs-on: ubuntu-latest
     steps:
       # Since this workflow is REQUIRED for a PR to be mergable, we have to have this 'if' statement in step level instead of job level.

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -35,7 +35,7 @@ jobs:
 
     issue:
       if: github.event_name == 'issues' && contains(github.event.issue.body, '@asyncapi/tsc_members')
-      name: On every new issue
+      name: TSC notification on every new issue
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown
@@ -53,7 +53,7 @@ jobs:
 
     pull_request:
       if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@asyncapi/tsc_members')
-      name: On every new pull request
+      name: TSC notification on every new pull request
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown
@@ -71,7 +71,7 @@ jobs:
     
     discussion:
       if: github.event_name == 'discussion' && contains(github.event.discussion.body, '@asyncapi/tsc_members')
-      name: On every new discussion
+      name: TSC notification on every new discussion
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown
@@ -89,7 +89,7 @@ jobs:
 
     issue_comment:
       if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members') }}
-      name: On every new comment in issue
+      name: TSC notification on every new comment in issue
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown
@@ -107,7 +107,7 @@ jobs:
 
     pr_comment:
       if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')
-      name: On every new comment in pr
+      name: TSC notification on every new comment in pr
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown
@@ -125,7 +125,7 @@ jobs:
 
     discussion_comment:
       if: github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@asyncapi/tsc_members')
-      name: On every new comment in discussion
+      name: TSC notification on every new comment in discussion
       runs-on: ubuntu-latest
       steps:
         - name: Convert markdown to slack markdown

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  slack:
+  slack-announce:
     name: Slack - notify on every release
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +26,7 @@ jobs:
             SLACK_MESSAGE: ${{steps.markdown.outputs.text}}
             MSG_MINIMAL: true
 
-  twitter:
+  twitter-announce:
     name: Twitter - notify on minor and major releases
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sentiment-analysis.yml
+++ b/.github/workflows/sentiment-analysis.yml
@@ -25,7 +25,7 @@ on:
             - created
             - edited
 jobs:
-    test:
+    sentiments:
         if: ${{ !contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]", "allcontributors"]'), github.actor) }}
         name: Checking sentiments
         runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   stale:
+    name: Mark issue or PR as stale
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v4.0.0

--- a/.github/workflows/welcome-first-time-contrib.yml
+++ b/.github/workflows/welcome-first-time-contrib.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   welcome:
+    name: Post welcome message
     if: ${{ !contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]", "allcontributors"]'), github.actor) }}
     runs-on: ubuntu-latest
     steps:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @derberg @alequetzalli @fmvilas @KhudaDad414 @github-actions[bot]
+* @derberg @alequetzalli @fmvilas @KhudaDad414 @asyncapi-bot-eve


### PR DESCRIPTION
GitHub started validating CODEOWNERS and now we know why automated assignment of reviewers to PRs never worked....because our CODEOWNERS files like https://github.com/asyncapi/.github/blob/master/CODEOWNERS were broken.

We are not allowed to add GitHub Actions bot to CODEOWNERS and this is why I created another bot, `asyncapi-bot-eve` that will be responsible for accepting PRs from `asyncapi-bot`.

`asyncapi-bot-eve` is already part of `bots` team where `asyncapi-bot` is. So it is already in all repos added as maintainer with rights to approve.

The only thing that is required after merge of this PR is that every maintainer needs to fix their CODEOWNERS by replacing `@github-actions[bot]` with `@asyncapi-bot-eve`

fixes https://github.com/asyncapi/.github/issues/112
also resolves https://github.com/asyncapi/.github/issues/140