### PR TITLE
ci: let autoupdate.yml run on pull_request

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -17,6 +17,13 @@ on:
       - 'dependabot/**'
       - 'bot/**'
       - 'all-contributors/**'
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches-ignore:  
+      - 'version-bump/**'
+      - 'dependabot/**'
+      - 'bot/**'
+      - 'all-contributors/**'
 
 jobs:
   autoupdate-for-bot:


### PR DESCRIPTION
**Description**

I’m thinking that the `autoupdate.yml` action that keeps release branches up-to-date with the destination branch (e.g. master ) should also run on creating a PR and not only on push event.
https://github.com/asyncapi/spec/blob/master/.github/workflows/autoupdate.yml#L13-L15

I recently created few PR’s in order to keep the release branches (`2022-04-release`) up-to-date with `master` branch . But I don’t want to wait until someone else pushes changes on those release branches. Instead, I would like the bot to update them ASAP. And this is not possible since the action is triggered only by the push event.

Does it make sense to also trigger it on `pull_request` event?
If not, please discard this PR.