### PR TITLE
fix: rename env from  `SLACK_DOCS_URL` to `SLACK_WEBHOOK_URL`

### DIFF
--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -28,5 +28,5 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,action,eventName,ref,workflow
       env:
-          SLACK_DOCS_CHANNEL: ${{ secrets.SLACK_DOCS_CHANNEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL }}
       if: failure() # Only, on failure, send a message on the Slack Docs Channel (if there are broken links)

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -26,7 +26,7 @@ jobs:
         # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
         # The default file is mlc_config.json, located at the root of the directory
         
-        # config-file: name-of-config-file
+        # config-file: name-of-config-file.json
 
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -24,9 +24,7 @@ jobs:
         
         # A configuration file can be included, indicating the properties of the link check action
         # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
-        # The default file is mlc_config.json, located at the root of the directory
-        
-        # config-file: name-of-config-file.json
+        # Create mlc_config.json file in the root of the directory
 
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
+        # A configuration file can be included, indicating the properties of the link check action
+        # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
+        # The default file is mlc_config.json, located at the root of the directory
+        
+        # config: name-of-config-file
 
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -21,11 +21,12 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
+        
         # A configuration file can be included, indicating the properties of the link check action
         # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
         # The default file is mlc_config.json, located at the root of the directory
         
-        # config: name-of-config-file
+        # config-file: name-of-config-file
 
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -17,4 +17,10 @@ jobs:
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
-        check-modified-files-only: 'yes' #Only modified files are checked on PRs
+        check-modified-files-only: 'yes' # Only modified files are checked on PRs
+        
+        # A configuration file can be included, indicating the properties of the link check action
+        # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
+        # The default file is mlc_config.json, located at the root of the directory
+        
+        # config: name-of-config-file.json

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -23,4 +23,4 @@ jobs:
         # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
         # The default file is mlc_config.json, located at the root of the directory
         
-        # config: name-of-config-file.json
+        # config-file: name-of-config-file.json

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -21,6 +21,4 @@ jobs:
         
         # A configuration file can be included, indicating the properties of the link check action
         # More information can be found here: https://github.com/tcort/markdown-link-check#config-file-format
-        # The default file is mlc_config.json, located at the root of the directory
-        
-        # config-file: name-of-config-file.json
+        # Create mlc_config.json file in the root of the directory


### PR DESCRIPTION
**Description**
Rename env from  `SLACK_DOCS_URL` to `SLACK_WEBHOOK_URL` in `link-check-cron.yml`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->