### PR TITLE
ci: fix autoupdate errors

### DIFF
--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -59,7 +59,7 @@ jobs:
             This PR is not up to date with the base branch and can't be merged.
             Please update your branch manually with the latest version of the base branch.
 
-            PRO-TIP: Add a comment to your PR with the text: `/au` or `/autoupdate` and our bot will take care of updating the branch in the future.
+            PRO-TIP: Add a comment to your PR with the text: `/au` or `/autoupdate` and our bot will take care of updating the branch in the future. The only requirement for this to work is to enable [Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) option in your PR.
             Thanks 😄 
 
       - name: Add ready-to-merge label

--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -57,7 +57,7 @@ jobs:
           body: |
             Hello, @${{ github.actor }}! 👋🏼
             This PR is not up to date with the base branch and can't be merged.
-            Please update your branch with latest version of the base branch.
+            Please update your branch manually with the latest version of the base branch.
 
             PRO-TIP: Add a comment to your PR with the text: `/au` or `/autoupdate` and our bot will take care of updating the branch in the future.
             Thanks 😄 

--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -58,8 +58,8 @@ jobs:
             Hello, @${{ github.actor }}! 👋🏼
             This PR is not up to date with the base branch and can't be merged.
             Please update your branch with latest version of the base branch.
-            
-            PRO-TIP: use `/au` or `/autoupdate` in the comment and our bot will take care of updating the branch in the future.
+
+            PRO-TIP: Add a comment to your PR with the text: `/au` or `/autoupdate` and our bot will take care of updating the branch in the future.
             Thanks 😄 
 
       - name: Add ready-to-merge label

--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -58,6 +58,8 @@ jobs:
             Hello, @${{ github.actor }}! 👋🏼
             This PR is not up to date with the base branch and can't be merged.
             Please update your branch with latest version of the base branch.
+            
+            PRO-TIP: use `/au` or `/autoupdate` in the comment and our bot will take care of updating the branch in the future.
             Thanks 😄 
 
       - name: Add ready-to-merge label

--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -42,23 +42,26 @@ jobs:
             await github.rest.repos.compareCommitsWithBasehead({
               owner: pull.head.repo.owner.login,
               repo: pull.head.repo.name,
-              basehead: `${pull.head.label}...${pull.base.label}`,
+              basehead: `${pull.base.label}...${pull.head.label}`,
             });
-            if (comparison.behind_by !== 0) isUpToDate = false;
+            if (comparison.behind_by !== 0) {
+              console.log(`This branch is behind the target by ${comparison.behind_by} commits`)
+              isUpToDate = false;
+            } else console.log(`This branch is up-to-date.`)
             return { isDraft, isUpToDate };
             
       - uses: actions-ecosystem/action-create-comment@v1
-        if: ${{ !steps.checkPR.outputs.result.isUpToDate }}
+        if: ${{ !fromJson(steps.checkPR.outputs.result).isUpToDate }}
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           body: |
             Hello, @${{ github.actor }}! 👋🏼
             This PR is not up to date with the base branch and can't be merged.
-            You can add comment to this PR with text: `/autoupdate` or `/au`. This way you ask our bot to perform regular updates for you. The only requirement for this to work is to enable [Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) option in your PR. Otherwise the only option that you have is to manually update your branch with latest version of the base branch.
+            Please update your branch with latest version of the base branch.
             Thanks 😄 
 
       - name: Add ready-to-merge label
-        if: ${{ !steps.checkPR.outputs.result.isDraft }}
+        if: ${{ !fromJson(steps.checkPR.outputs.result).isDraft }}
         uses: actions/github-script@v5
         with:
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -17,13 +17,9 @@ on:
       - 'dependabot/**'
       - 'bot/**'
       - 'all-contributors/**'
-  pull_request:
-    types:
-      - labeled
 
 jobs:
   autoupdate-for-bot:
-    if: ${{ !github.event.issue.pull_request || contains(github.event.pull_request.labels.*.name, 'autoupdate') }}
     name: Autoupdate autoapproved PR created in the upstream
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -25,7 +25,7 @@ jobs:
 
             - `/ready-to-merge` or `/rtm` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
             - `/do-not-merge` or `/dnm` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
-            - `/autoupdate` or `/au` - This comment will add `autoupdate` label to the PR and keeps your PR up-to-date to the target branch. Unless there is a merge conflict.
+            - `/autoupdate` or `/au` - This comment will add `autoupdate` label to the PR and keeps your PR up-to-date to the target branch's future changes. Unless there is a merge conflict.
   create_help_comment_issue:
     if: ${{ !github.event.issue.pull_request && contains(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**

- This PR removes the ability to update the PR branch with `/autoupdate` but it will still keep the PR's branch updated against the **FUTURE** changes to the target branch.
- Resolves the issue where it posts a comment even if the PR branch is up-to-date. https://github.com/asyncapi/website/pull/644#issuecomment-1088867508
- The ability to update the PR with `/autoupdate` will be added in the follow-up commits. Or a follow-up PR if we want to merge it quickly.