### PR TITLE
fix: improve markdown links validation

### DIFF
--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Checks the status of hyperlinks in .md files
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: derberg/github-action-markdown-link-check@temporary-fix
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Report workflow run status to Slack
       uses: 8398a7/action-slack@v3
       with:
-          status: ${{ job.status }}
-          fields: repo,message,action,eventName,ref,workflow
+        status: ${{ job.status }}
+        fields: repo,action,workflow
       env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL }}
       if: failure() # Only, on failure, send a message on the Slack Docs Channel (if there are broken links)

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -6,12 +6,17 @@ name: Check Markdown links
 on: 
   pull_request_target:
     types: [synchronize, ready_for_review, opened, reopened]
-
+    paths:
+      - '**.md'
+      
 jobs:
   External-link-validation-on-PR:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Do come Git magic
+      run: git config --global --add safe.directory /github/workspace
     - name: Check links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -8,17 +8,15 @@ on:
     types: [synchronize, ready_for_review, opened, reopened]
     paths:
       - '**.md'
-      
+
 jobs:
   External-link-validation-on-PR:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-    - name: Do come Git magic
-      run: git config --global --add safe.directory /github/workspace
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: derberg/github-action-markdown-link-check@temporary-fix
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'


### PR DESCRIPTION
**Description**

- new git command related to https://stackoverflow.com/questions/71849415/cannot-add-parent-directory-to-safe-directory-on-git
- modified slack notification to share only relevant details for the cron-scheduled validation