### PR TITLE
ci: improve out-of-date message on PRs + some other minor issues

### DIFF
--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -50,7 +50,7 @@ jobs:
               repo: pull.head.repo.name,
               basehead: `${pull.base.label}...${pull.head.label}`,
             });
-            if (comparison.behind_by !== 0) {
+            if (comparison.behind_by !== 0 && pull.mergeable_state === 'behind') {
               console.log(`This branch is behind the target by ${comparison.behind_by} commits`)
               console.log('adding out-of-date comment...');
               github.rest.issues.createComment({

--- a/.github/workflows/automerge-orphans.yml
+++ b/.github/workflows/automerge-orphans.yml
@@ -57,7 +57,7 @@ jobs:
         name: Send info about orphan to slack
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}
+          SLACK_WEBHOOK: ${{secrets.SLACK_CI_FAIL_NOTIFY}}
           SLACK_TITLE: 🚨 Not merged PR that should be automerged 🚨
           SLACK_MESSAGE: ${{steps.issuemarkdown.outputs.text}}
           MSG_MINIMAL: true

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -32,5 +32,5 @@ jobs:
         status: ${{ job.status }}
         fields: repo,action,workflow
       env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
       if: failure() # Only, on failure, send a message on the Slack Docs Channel (if there are broken links)

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Checks the status of hyperlinks in .md files
     - name: Check links
-      uses: derberg/github-action-markdown-link-check@temporary-fix
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Check links
-      uses: derberg/github-action-markdown-link-check@temporary-fix
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'


### PR DESCRIPTION
**Description**

- Don't show the out-of-date message if the branch is not protected.
for example:  https://github.com/asyncapi/spec-json-schemas/pull/199#issuecomment-1097698492, https://github.com/asyncapi/spec/pull/584#issuecomment-1099024685

fixes #158 