### PR TITLE
ci: change token for autoupdate to use codeowner token

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Autoupdating
         uses: docker://chinthakagodawita/autoupdate-action:v1
         env:
-          GITHUB_TOKEN: '${{ secrets.GH_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GH_TOKEN_BOT_EVE }}'
           PR_FILTER: "labelled"
           PR_LABELS: "autoupdate"
           PR_READY_STATE: "ready_for_review"


### PR DESCRIPTION
Autoupdate do not work with forks -> https://github.com/asyncapi/website/runs/6361700980?check_suite_focus=true

Reason is that we use there token of wrong bot, `Eve` is the right one as `Eve` is a codeowner in all projects, so only `Eve` bot have `write` access to forks as a valid maintainer.

At least I think this is the solution 😆 