### PR TITLE
ci: replicate COC.md to all repositories

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -2,11 +2,11 @@ name: Global workflow to rule them all
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     paths:
-      - '.github/workflows/**'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
+      - ".github/workflows/**"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
   workflow_dispatch:
     inputs:
       repo_name:
@@ -16,11 +16,10 @@ on:
         required: false
 
 jobs:
-
   replicate_coc:
-      name: Replicate Code of Conduct in all repositories
-      runs-on: ubuntu-latest
-      steps:
+    name: Replicate Code of Conduct in all repositories
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
@@ -28,15 +27,15 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CODE_OF_CONDUCT.md
+          repos_to_ignore: shape-up-process,glee-hello-world
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "chore: update code of conduct"
-          repos_to_ignore: shape-up-process,glee-hello-world
 
   replicate_contributing:
-      name: Replicate CONTRIBUTING guide to all repositories
-      runs-on: ubuntu-latest
-      steps:
+    name: Replicate CONTRIBUTING guide to all repositories
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
@@ -50,9 +49,9 @@ jobs:
           commit_message: "ci: update global contribution guide"
 
   replicate_go_workflows:
-      name: Replicate workflows for Go projects
-      runs-on: ubuntu-latest
-      steps:
+    name: Replicate workflows for Go projects
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
@@ -66,9 +65,9 @@ jobs:
           commit_message: "ci: update workflows for go projects"
 
   replicate_nodejs_workflows:
-      name: Replicate workflows for Nodejs projects
-      runs-on: ubuntu-latest
-      steps:
+    name: Replicate workflows for Nodejs projects
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
@@ -80,11 +79,11 @@ jobs:
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update workflows for nodejs projects"
-      
+
   replicate_generic_workflows:
-      name: Replicate generic workflows needed for any project
-      runs-on: ubuntu-latest
-      steps:
+    name: Replicate generic workflows needed for any project
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
@@ -101,14 +100,14 @@ jobs:
     name: Replicate Docker workflows needed for any project
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Replicating file
-      uses: derberg/copy-files-to-other-repositories@v1.0.0
-      with:
-        github_token: ${{ secrets.GH_TOKEN }}
-        topics_to_include: docker
-        patterns_to_include: .github/workflows/if-docker-pr-testing.yml
-        committer_username: asyncapi-bot
-        committer_email: info@asyncapi.io
-        commit_message: "ci: update workflows for docker-based projects"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Replicating file
+        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          topics_to_include: docker
+          patterns_to_include: .github/workflows/if-docker-pr-testing.yml
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          commit_message: "ci: update workflows for docker-based projects"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,25 +2,25 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 


### PR DESCRIPTION
Signed-off-by: amino19 <anshumaankrprasad76@gmail.com>

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

To replicate the `CODE_OF_CONDUCT.md` (COC.md) file to all repositories in the AsyncAPI organization, @derberg suggested me to do a "simple editorial change" in the [COC.md](https://github.com/asyncapi/.github/blob/master/CODE_OF_CONDUCT.md) file; my changes are as follows:
- bullets point `star` to `hyphen` in COC.md
- Restructure GitHub Action for [global-replicator.yml](https://github.com/asyncapi/.github/blob/master/.github/workflows/global-replicator.yml)
- removed [line 34](https://github.com/asyncapi/.github/blob/master/.github/workflows/global-replicator.yml#L34) and bring it between L30 & L31. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #167 