### PR TITLE
ci: fix version bump workflow and make sure in future we get notified

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -48,6 +48,15 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'
         name: Run test
         run: npm test
+      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'Release workflow failed in testing job'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
 
   release:
     needs: [test-nodejs]
@@ -84,3 +93,12 @@ jobs:
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
         run: npm run release
+      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'Release workflow failed in release job'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -48,7 +48,7 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'
         name: Run test
         run: npm test
-      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3
         with:
@@ -93,7 +93,7 @@ jobs:
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
         run: npm run release
-      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -25,6 +25,13 @@ jobs:
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
@@ -46,4 +53,13 @@ jobs:
           author: asyncapi-bot <info@asyncapi.io>
           title: 'chore(release): ${{github.event.release.tag_name}}'
           body: 'Version bump in package.json for release [${{github.event.release.tag_name}}](${{github.event.release.html_url}})'
-          branch: version-bump/${{github.event.release.tag_name}} 
+          branch: version-bump/${{github.event.release.tag_name}}
+      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+        name: Report workflow run status to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,action,workflow
+          text: 'Unable to bump the version in package.json after the release'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -54,7 +54,7 @@ jobs:
           title: 'chore(release): ${{github.event.release.tag_name}}'
           body: 'Version bump in package.json for release [${{github.event.release.tag_name}}](${{github.event.release.html_url}})'
           branch: version-bump/${{github.event.release.tag_name}}
-      - if: failure() # Only, on failure, send a message on the Slack Docs Channel
+      - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -34,4 +34,4 @@ jobs:
         fields: repo,action,workflow
       env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_FAIL_NOTIFY }}
-      if: failure() # Only, on failure, send a message on the Slack Docs Channel (if there are broken links)
+      if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel


### PR DESCRIPTION
related to https://github.com/asyncapi/dotnet-nats-template/actions/runs/2536516647 and we learned that for at least a month the version bump workflow doesn't work

this PR:
- make sure bump version works the same way release and pr testing workflows
- add slack notifications in case of these workflows fail