### PR TITLE
ci: use latest global workflow to fix manual run

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CODE_OF_CONDUCT.md
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CONTRIBUTING.md
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/if-go-pr-testing.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/if-nodejs-pr-testing.yml,.github/workflows/if-nodejs-release.yml,.github/workflows/if-nodejs-version-bump.yml,.github/workflows/bump.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml,.github/workflows/add-good-first-issue-labels.yml,.github/workflows/automerge-for-humans-merging.yml,.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml,.github/workflows/automerge-orphans.yml,.github/workflows/automerge.yml,.github/workflows/autoupdate.yml,.github/workflows/help-command.yml,.github/workflows/issues-prs-notifications.yml,.github/workflows/lint-pr-title.yml,.github/workflows/notify-tsc-members-mention.yml,.github/workflows/sentiment-analysis.yml,.github/workflows/stale-issues-prs.yml,.github/workflows/welcome-first-time-contrib.yml,.github/workflows/release-announcements.yml,.github/workflows/link-check-cron.yml,.github/workflows/link-check-pr.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Replicating file
-        uses: derberg/copy-files-to-other-repositories@v1.0.0
+        uses: derberg/copy-files-to-other-repositories@v1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           topics_to_include: docker


### PR DESCRIPTION
this PR makes us use global workflow `v1` so it is easier to apply patches from the action. Latest patch is with the fix to make `workflow_dispatch` trigger work as expected, as not it was always reporting that no files need replication, even though it is not true.