### PR TITLE
ci: close staled issues with `not planned` reason

### DIFF
--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -13,7 +13,7 @@ jobs:
     name: Mark issue or PR as stale
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v4.0.0
+    - uses: actions/stale@v5.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: |

--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -42,3 +42,4 @@ jobs:
         stale-pr-label: stale
         exempt-issue-labels: keep-open
         exempt-pr-labels: keep-open
+        close-issue-reason: not_planned


### PR DESCRIPTION
**Description**

This PR forces the `stale-issues-prs` workflow to close staled issues with the `not planned` reason instead of `completed`, as per completed means a fix, feature, or any other work has been done in order to close it, which in our community, it doesn't happen; we manually close issues that has been fixed/resolved, and stale issues are normally things we won't do.  

**Related issue(s)**
Example of issue that has been marked as `completed` but shouldn't: https://github.com/asyncapi/spec/issues/596