### PR TITLE
feat: add error comment in lint-pr-title.yml

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -25,7 +25,7 @@ jobs:
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" should start with a lowercase character.
             
-      # Comments the error message from the above lint_pr_title action and deletes the comment when the linting is correct
+      # Comments the error message from the above lint_pr_title action 
       - if: always()
         name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           header: comment
           message: |
-                   ```
+                   ```Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.<br />
+                   We require all PRs to follow Conventional Commits specification. More details 👇🏼
                     ${{ steps.lint_pr_title.outputs.error_message}}
                    ```
        # deletes the error comment if the title is correct            

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -35,6 +35,8 @@ jobs:
                    ```
                    Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request. 
                    We require all PRs to follow Conventional Commits specification. More details 👇🏼
+                   
+                   
                     ${{ steps.lint_pr_title.outputs.error_message}}
                    ```
        # deletes the error comment if the title is correct            

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -33,7 +33,8 @@ jobs:
           header: comment
           message: |
                    ```
-                   Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.<br/> We require all PRs to follow Conventional Commits specification. More details 👇🏼
+                   Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request. 
+                   We require all PRs to follow Conventional Commits specification. More details 👇🏼
                     ${{ steps.lint_pr_title.outputs.error_message}}
                    ```
        # deletes the error comment if the title is correct            

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,23 +1,46 @@
 # This action is centrally managed in https://github.com/asyncapi/.github/
 # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
 
+
+
 name: Lint PR title
 
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, edited, ready_for_review]
-
+    
 jobs:
   lint-pr-title:
-    name: Lint PR title
-    runs-on: ubuntu-latest
-    steps:
+   name: Lint PR title
+   runs-on: ubuntu-latest
+   steps:
       # Since this workflow is REQUIRED for a PR to be mergable, we have to have this 'if' statement in step level instead of job level.
       - if: ${{ !contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]", "allcontributors"]'), github.actor) }}
-        uses: amannn/action-semantic-pull-request@v3.2.5
+        uses: Krishks369/action-semantic-pull-request@3fb9141f164e97c267a18fe560474547fd7f1fff
+        id: lint_pr_title
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" should start with a lowercase character.
+            
+      # Comments the error message from the above lint_pr_title action and deletes the comment when the linting is correct
+      - if: always()
+        name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: comment
+          message: |
+                   ```
+                    ${{ steps.lint_pr_title.outputs.error_message}}
+                   ```
+       # deletes the error comment if the title is correct            
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        name: delete the comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:   
+          header: comment
+          delete: true
+ 
+        

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           header: comment
           message: |
-                   ```Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.<br />
+                   ```Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.
                    We require all PRs to follow Conventional Commits specification. More details 👇🏼
                     ${{ steps.lint_pr_title.outputs.error_message}}
                    ```

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           header: comment
           message: |
-                   ```Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.
-                   We require all PRs to follow Conventional Commits specification. More details 👇🏼
+                   ```
+                   Hey there 👋🏼 thanks for opening the PR but we need you to adjust the title of the pull request.<br/> We require all PRs to follow Conventional Commits specification. More details 👇🏼
                     ${{ steps.lint_pr_title.outputs.error_message}}
                    ```
        # deletes the error comment if the title is correct            


### PR DESCRIPTION
I have added feature in the lint-pr-title.yml file to comment on the lint errors in the title while PR is created

 **Three scenarios are there for the workflow**

1.  When the PR title is not in the correct format i.e when it is apart from titles like `feat`, `fix` etc. It works like it has in this [PR](https://github.com/Krishks369/.github/pull/16) .

2. When the PR title is not found or the PR subject starts in capital, then it works like in this [PR](https://github.com/Krishks369/.github/pull/17)

3. When the lint is corrected after the comment, the comment is then deleted from the PR, as mentioned in https://github.com/marocchino/sticky-pull-request-comment

Although the action used for linting the title is https://github.com/amannn/action-semantic-pull-request  I have forked and used this feature before it got merged in the main action. So temporarily it uses https://github.com/Krishks369/action-semantic-pull-request.
  
 