### PR TITLE
ci: support co-authoring for auto-merged PRs

### DIFF
--- a/.github/workflows/automerge-for-humans-merging.yml
+++ b/.github/workflows/automerge-for-humans-merging.yml
@@ -25,6 +25,14 @@ jobs:
         uses: sergeysova/jq-action@v2
         id: authors
         with:
+          # This cmd does following (line by line):
+          # 1. CURL querying the list of commits of the current PR via GH API. Why? Because the current event payload does not carry info about the commits.
+          # 2. Iterates over the previous returned payload, and creates an array with the filtered results (see below) so we can work wit it later. An example of payload can be found in https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-34.
+          # 3. Grabs the data we need for adding the `Co-authored-by: ...` lines later and puts it into objects to be used later on.
+          # 4. Filters the results by excluding the current PR sender. We don't need to add it as co-author since is the PR creator and it will become by default the main author.
+          # 5. Removes repeated authors (authors can have more than one commit in the PR).
+          # 6. Builds the `Co-authored-by: ...` lines with actual info.
+          # 7. Transforms the array into plain text. Thanks to this, the actual stdout of this step can be used by the next Workflow step (wich is basically the automerge).
           cmd: | 
             curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "${{github.event.pull_request._links.commits.href}}?per_page=100" 
               | jq -r '[.[] 
@@ -40,6 +48,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           MERGE_LABELS: "!do-not-merge,ready-to-merge"
           MERGE_METHOD: "squash"
+          # Using the output of the previous step (`Co-authored-by: ...` lines) as commit description.
           # Important to keep 2 empty lines as https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line mentions
           MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})\n\n\n${{ steps.authors.outputs.value }}" 
           MERGE_RETRIES: "20"

--- a/.github/workflows/automerge-for-humans-merging.yml
+++ b/.github/workflows/automerge-for-humans-merging.yml
@@ -26,7 +26,13 @@ jobs:
         id: authors
         with:
           cmd: | 
-            curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "${{github.event.pull_request._links.commits.href}}?per_page=100" | jq -r '[.[] | {name: .commit.author.name, email: .commit.author.email, login: .author.login}] | map(select(.login != "${{github.event.pull_request.user.login}}")) | unique | map("Co-authored-by: " + .name + " <" + .email + ">") | join("\n")'
+            curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "${{github.event.pull_request._links.commits.href}}?per_page=100" 
+              | jq -r '[.[] 
+                | {name: .commit.author.name, email: .commit.author.email, login: .author.login}] 
+                | map(select(.login != "${{github.event.pull_request.user.login}}")) 
+                | unique 
+                | map("Co-authored-by: " + .name + " <" + .email + ">") 
+                | join("\n")'
           multiline: true
       - name: Automerge PR
         uses: pascalgn/automerge-action@v0.14.3

--- a/.github/workflows/automerge-for-humans-merging.yml
+++ b/.github/workflows/automerge-for-humans-merging.yml
@@ -21,12 +21,20 @@ jobs:
     if: github.event.pull_request.draft == false && (github.event.pull_request.user.login != 'asyncapi-bot' || github.event.pull_request.user.login != 'dependabot[bot]' || github.event.pull_request.user.login != 'dependabot-preview[bot]') #it runs only if PR actor is not a bot, at least not a bot that we know
     runs-on: ubuntu-latest
     steps:
+      - name: Get list of authors
+        uses: sergeysova/jq-action@v2
+        id: authors
+        with:
+          cmd: | 
+            curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "${{github.event.pull_request._links.commits.href}}?per_page=100" | jq -r '[.[] | {name: .commit.author.name, email: .commit.author.email, login: .author.login}] | map(select(.login != "${{github.event.pull_request.user.login}}")) | unique | map("Co-authored-by: " + .name + " <" + .email + ">") | join("\n")'
+          multiline: true
       - name: Automerge PR
         uses: pascalgn/automerge-action@v0.14.3
         env:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           MERGE_LABELS: "!do-not-merge,ready-to-merge"
           MERGE_METHOD: "squash"
-          MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
+          # Important to keep 2 empty lines as https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line mentions
+          MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})\n\n\n${{ steps.authors.outputs.value }}" 
           MERGE_RETRIES: "20"
           MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
**Description**

Something I realized we might need to think about is the fact merging release branches (i.e. `next-major`  or `next-spec`) with squash merging strategy ends up obviously with only one commit being merged, being the author of it the person who created the PR. 

This leads to:
- Losing history of changes introduced. It might not be a real issue (if it hasn’t yet) since we write version notes. However, it’s hard to see where exactly a feature or bug was introduced.
- Losing authority of commits. All changes to such version will appear to be introduced by the person who created the PR.

For the record, the merge is performed automatically by @asyncapi-bot  thanks to the `automerge-for-humans-merging.yml` Github workflow.

This PR fixes the issue with authority, by adding co-authors to the final commit (the one that ends up being merged). See https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line.

You can see the workflow running on this test repository I created:

- PR: https://github.com/smoya/automerge-coauthoring/pull/1
  - The PR has two commits, one by a fictitious user `jciment`, another is made by me; `smoya`.
The merged commit: https://github.com/smoya/automerge-coauthoring/commit/7071981116569eb1c8d6e008d4717034a8837353
  - The commit contains `Co-authored-by: Sergio Moya <1083296+smoya@users.noreply.github.com>`.
  - GH UI shows the co-author as expected: 
![screenshot](https://user-images.githubusercontent.com/1083296/190007706-8932d22e-a886-4286-83a4-91eedbc744ea.png)

Examples:

- spec 2.4.0:
  - PR opened by @Sergio Moya: https://github.com/asyncapi/spec/pull/740
    - You can notice there are several commits merged into that PR, from several authors.
  - The actual merged commit, being @Sergio Moya the only author: https://github.com/asyncapi/spec/commit/65d58696f8c3ab6471aa48b12d878221b8d8109e

The same will happen with the 2.0.0 version of the parser-js https://github.com/asyncapi/parser-js/pull/598. And same with version 3 of the spec (this time @jonaslagoni will be the author of the whole v3 spec!): https://github.com/asyncapi/spec/pull/759

**Related issue(s)**
Slack 🧵 https://asyncapi.slack.com/archives/CQVJXFNQL/p1662972475762699

cc @derberg @fmvilas @jonaslagoni @magicmatatjahu 