### PR TITLE
ci: fix link checker and stale bot

### DIFF
--- a/.github/workflows/link-check-cron.yml
+++ b/.github/workflows/link-check-cron.yml
@@ -18,7 +18,7 @@ jobs:
 
     # Checks the status of hyperlinks in .md files
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@0a51127e9955b855a9bbfa1ff5577f1d1338c9a5 #1.0.14 but pointing to commit for security reasons
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/link-check-pr.yml
+++ b/.github/workflows/link-check-pr.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Check links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@0a51127e9955b855a9bbfa1ff5577f1d1338c9a5 #1.0.14 but pointing to commit for security reasons
       with:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'

--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -13,7 +13,7 @@ jobs:
     name: Mark issue or PR as stale
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v5.1.0
+    - uses: actions/stale@99b6c709598e2b0d0841cd037aaf1ba07a4410bd #v5.2.0 but pointing to commit for security reasons
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: |


### PR DESCRIPTION
- stale bot was staling issues and next day automatically unstaling - this is fixed with latest version
- link checker was in general behaving weird and throwing lots of false-positives

as you can see, I also started using commits as version pointers. We have global replicator, so we have luxury to use commits, instead invented GH Actions versioning, that is super insecure. I'm happy to explain more if needed