### PR TITLE
ci: fix bot comment shows up only when PR title is wrong

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -26,7 +26,7 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}" should start with a lowercase character.
             
       # Comments the error message from the above lint_pr_title action 
-      - if: ${{always() &&  !contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]", "allcontributors"]'), github.actor)}}
+      - if: ${{steps.lint_pr_title.outputs.error_message != null && !contains(fromJson('["asyncapi-bot", "dependabot[bot]", "dependabot-preview[bot]", "allcontributors"]'), github.actor)}}
         name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443    #version 2.2
         with:


### PR DESCRIPTION
Updated the job to run only if the error message is not null. So that Blank Comment doesn't happen