### PR TITLE
fix: improve email notifications for tsc voting

### DIFF
--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -204,7 +204,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}', '${{github.event.issue.title}}'');
+            sendEmail('${{github.event.comment.html_url}}', '${{github.event.issue.title}}');
 
   pr_comment:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -8,28 +8,22 @@ on:
   issue_comment:
     types:
       - created
-      - edited
 
   discussion_comment:
     types:
       - created
-      - edited
 
   issues:
     types:
       - opened
-      - reopened
 
   pull_request_target:
     types:
       - opened
-      - reopened
-      - ready_for_review
 
   discussion:
     types:
       - created
-      - edited
 
 jobs:
   issue:
@@ -75,7 +69,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.issue.html_url}}');
+            sendEmail('${{github.event.issue.html_url}}', '${{github.event.issue.title}}');
 
   pull_request:
     if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@asyncapi/tsc_members')
@@ -120,7 +114,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.pull_request.html_url}}');
+            sendEmail('${{github.event.pull_request.html_url}}', '${{github.event.pull_request.title}}');
 
   discussion:
     if: github.event_name == 'discussion' && contains(github.event.discussion.body, '@asyncapi/tsc_members')
@@ -165,7 +159,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.discussion.html_url}}');
+            sendEmail('${{github.event.discussion.html_url}}', '${{github.event.discussion.title}}');
 
   issue_comment:
     if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members') }}
@@ -210,7 +204,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}');
+            sendEmail('${{github.event.comment.html_url}}', '${{github.event.issue.title}}'');
 
   pr_comment:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')
@@ -255,7 +249,7 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}');
+            sendEmail('${{github.event.comment.html_url}}', '${{github.event.issue.title}}');
 
   discussion_comment:
     if: github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@asyncapi/tsc_members')
@@ -300,4 +294,4 @@ jobs:
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}');
+            sendEmail('${{github.event.comment.html_url}}', '${{github.event.discussion.title}}');

--- a/.github/workflows/scripts/mailchimp/htmlContent.js
+++ b/.github/workflows/scripts/mailchimp/htmlContent.js
@@ -2,7 +2,7 @@
  * This code is centrally managed in https://github.com/asyncapi/.github/
  * Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
  */
-module.exports = (link) => {
+module.exports = (link, title) => {
 
     return `<!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
@@ -386,7 +386,7 @@ There is a new topic at AsyncAPI Initiative that requires Technical Steering Com
 <br>
 Please have a look if it is just something you need to be aware of, or maybe your vote is needed.
 <br>
-<a href="${ link }" style="color:#007c89;font-weight:normal;text-decoration:underline" target="_blank">Click here to see more details on GitHub</a>.
+Topic: <a href="${ link }" style="color:#007c89;font-weight:normal;text-decoration:underline" target="_blank">${ title }</a>.
                         </td>
                     </tr>
                 </tbody></table>

--- a/.github/workflows/scripts/mailchimp/index.js
+++ b/.github/workflows/scripts/mailchimp/index.js
@@ -10,7 +10,7 @@ const htmlContent = require('./htmlContent.js');
  * Sending API request to mailchimp to schedule email to subscribers
  * Input is the URL to issue/discussion or other resource
  */
-module.exports = async (link) => {
+module.exports = async (link, title) => {
 
     let newCampaign;
 
@@ -32,7 +32,7 @@ module.exports = async (link) => {
                 }
             },
             settings: {
-                subject_line: 'AsyncAPI TSC members attention required',
+                subject_line: `TSC attention required: ${ title }`,
                 preview_text: 'Check out the latest topic that TSC members have to be aware of',
                 title: `New topic info - ${ new Date(Date.now()).toUTCString()}`,
                 from_name: 'AsyncAPI Initiative',
@@ -47,7 +47,7 @@ module.exports = async (link) => {
     * Content of the email is added separately after campaign creation
     */
     try {
-        await mailchimp.campaigns.setContent(newCampaign.id, { html: htmlContent(link) });
+        await mailchimp.campaigns.setContent(newCampaign.id, { html: htmlContent(link, title) });
     } catch (error) {
         return core.setFailed(`Failed adding content to campaign: ${ JSON.stringify(error) }`);
     }


### PR DESCRIPTION
**Description**

- title of issue/pr/discussion will now be included in body of email and the email title
- action will not react on edits as already because of it, few times we sent duplicated emails to people. We need to avoid to much spam

**Related issue(s)**
Resolves https://github.com/asyncapi/.github/issues/194