### PR TITLE
ci: improve release workflows to skip early

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -22,7 +22,12 @@ jobs:
     # We just check the message of first commit as there is always just one commit because we squash into one before merging
     # "commits" contains array of objects where one of the properties is commit "message"
     # Release workflow will be skipped if release conventional commits are not used
-    if: ${{ !startsWith(fromJson('["fix:", "feat:", "fix!:", "feat!:"]'), github.event.push.commits[0].message) }}
+    if: |
+      startsWith( github.repository, 'asyncapi/' ) && 
+      (startsWith( github.event.commits[0].message , 'fix:' ) ||
+      startsWith( github.event.commits[0].message, 'fix!:' ) ||
+      startsWith( github.event.commits[0].message, 'feat:' ) ||
+      startsWith( github.event.commits[0].message, 'feat!:' ))
     name: Test NodeJS release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -19,6 +19,10 @@ on:
 jobs:
 
   test-nodejs:
+    # We just check the message of first commit as there is always just one commit because we squash into one before merging
+    # "commits" contains array of objects where one of the properties is commit "message"
+    # Release workflow will be skipped if release conventional commits are not used
+    if: ${{ !startsWith(fromJson('["fix:", "feat:", "fix!:", "feat!:"]'), github.event.push.commits[0].message) }}
     name: Test NodeJS release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
**Description**

- this change will significantly improve GitHub Actions workload as at the moment release workflow is triggered on every single commit, and tests have to go through until `semantic-release` finds out release is not needed
- I use `startsWith(fromJson` and not `contains(fromJson` like in other workflows because commit message can be multiline, and we do not have 100% assurance that PR was not manually merged and feat/fix was not mentioned somewhere in the message
- I checked if `startsWith` also works with `contains` as there is not direct info in docs, at least I did not find it. I just searched github and found https://github.com/insignias/React/blob/main/.github/workflows/merge-release-pr-to-main.yml#L40

**Related issue(s)**
Resolves https://github.com/asyncapi/.github/issues/184