### PR TITLE
fix: emails not being sent to proper recipients

### DIFF
--- a/.github/workflows/scripts/mailchimp/index.js
+++ b/.github/workflows/scripts/mailchimp/index.js
@@ -27,8 +27,14 @@ module.exports = async (link, title) => {
             type: 'regular',
             recipients: {
                 list_id: '6e3e437abe',
-                segments_opts: {
-                    saved_segment_id: 'tsc-voting-email'
+                segment_opts: {
+                    match: 'any',
+                    conditions: [{
+                        condition_type: 'Interests',
+                        field: 'interests-2801e38b9f',
+                        op: 'interestcontains',
+                        value: ['f7204f9b90']
+                    }]
                 }
             },
             settings: {


### PR DESCRIPTION
This PR is fixing a bug that was sending the TSC notification email to all the people in our Mailchimp list, instead of just the ones subscribed to this kind of notification.