### PR TITLE
chore: update new name of php template in generic workflow

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CONTRIBUTING.md
-          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,asyncapi-php-template,tck,modelina,dotnet-nats-template,ts-nats-template
+          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update global contribution guide"


### PR DESCRIPTION
updating name of PHP template as it is not ignored for now and recently bot override the contributors guide that is custom in `php-template`

@KhudaDad414 easy approval 😉 