### PR TITLE
feat: github action to check the merge conflict on push

### DIFF
--- a/.github/workflows/merge_conflicts.yaml
+++ b/.github/workflows/merge_conflicts.yaml
@@ -1,0 +1,18 @@
+name: Auto Comment Merge Conflicts
+
+on: push
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-comment-merge-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codytseng/auto-comment-merge-conflicts@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: "Hey there 👋🏼, your current PR has some merge conflicts. KIndly try to resolve them in your local fork and push the new changes."
+          wait-ms: 3000
+          max-retries: 5
+          ignore-authors: asyncapi-bot,dependabot[bot],dependabot-preview[bot],allcontributors


### PR DESCRIPTION
**Description**

current PR adds a github actions which will check all the open PR when a push commit is made and will leave a comment if there is a merge conflict.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #181 