### PR TITLE
ci: node pipelines now setup node version depending on `lockfileVersion`

### DIFF
--- a/.github/actions/get-node-version-from-package-lock/action.yml
+++ b/.github/actions/get-node-version-from-package-lock/action.yml
@@ -1,0 +1,43 @@
+name: 'Specify Node version basing on package-lock file version'
+outputs:
+  version:
+    description: 'Node.js version number to use with actions/setup-node action'
+    value: ${{ steps.getnode.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
+        cache-dependency-path: '**/package-lock.json'
+    - name: Get Node version
+      uses: actions/github-script@v6
+      id: getnode
+      with:
+        script: |
+          const { resolve } = require('path');
+          const packageLockLocation = './package-lock.json';
+          core.info(`Location of the packae-lock verification script is: ${ resolve(packageLockLocation) }`)
+          const packageLock = require(packageLockLocation);
+
+          const packageLockVersion = packageLock.lockfileVersion;
+          let nodeVersion;
+
+          switch (packageLockVersion) {
+            case 1:
+                nodeVersion = '14'
+                break;
+            case 2:
+                nodeVersion = '16'
+                break;
+            case 3:
+                nodeVersion = '18'
+                break;
+            default:
+                nodeVersion = '16'
+                break;
+          }
+
+          core.setOutput('version', nodeVersion);

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -51,10 +51,14 @@ jobs:
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        id: lockversion
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -45,10 +45,14 @@ jobs:
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        id: lockversion
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'
@@ -82,10 +86,16 @@ jobs:
         id: packagejson
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        id: lockversion
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "${{ steps.lockversion.outputs.version }}"
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
         run: npm install

--- a/.github/workflows/if-nodejs-version-bump.yml
+++ b/.github/workflows/if-nodejs-version-bump.yml
@@ -25,10 +25,14 @@ jobs:
         id: packagejson
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
       - if: steps.packagejson.outputs.exists == 'true'
+        name: Check package-lock version
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        id: lockversion
+      - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "${{ steps.lockversion.outputs.version }}"
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'


### PR DESCRIPTION
This is related to very annoying thing about current pipelines, that they are set to Node 14 and in many projects package-lock v2 and even v3 is used, for newer versions of Node. As a result, many times happens that installation of project fail because of inconsistent support between old npm and new package lock structure.

more in https://github.com/asyncapi/.github/pull/187

so what is this PR introducing:
- composite action that can be reused across all repos and we can use it to verify version of package lock, and output proper node version that should be used
- modify pipelines that require Node setup to setup version of the node that given package-lock.json requires