### PR TITLE
ci: update global workflow and cleanup release config file

### DIFF
--- a/.github/workflows/global-remover.yml
+++ b/.github/workflows/global-remover.yml
@@ -1,0 +1,53 @@
+name: Global workflow to use when some file from repos has to be remove
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+    inputs:
+      repo_name:
+        description: |
+          You can specify the repository's name where workflows should be pushed manually, as long as workflow settings do not ignore the repository.
+          If you do not specify the exact repository name, the workflow will try to replicate all missing changes to all repositories.
+        required: false
+
+jobs:
+  # these should not be located under .github/workflows but on root
+  # the other workflow push them to root already
+  remove_semantic_release_config:
+    if: startsWith(github.repository, 'asyncapi/')
+    name: remove .releaserc file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Removing
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          patterns_to_remove: .github/workflows/.releaserc
+          topics_to_include: get-global-releaserc
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
+
+  replicate_generic_workflows:
+    if: startsWith(github.repository, 'asyncapi/')
+    name: remove workflow files that are not supposed to be used
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Removing
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          patterns_to_remove: .github/workflows/sentiment-analysis.yml,.github/workflows/link-check-cron.yml,.github/workflows/link-check-pr.yml
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          commit_message: "ci: update of files from global .github repo"
+          repos_to_ignore: shape-up-process,glee-hello-world
+          bot_branch_name: bot/update-files-from-global-repo

--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -24,14 +24,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CODE_OF_CONDUCT.md
           repos_to_ignore: shape-up-process,glee-hello-world
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "chore: update code of conduct"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_contributing:
     if: startsWith(github.repository, 'asyncapi/')
@@ -41,14 +42,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CONTRIBUTING.md
           repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update global contribution guide"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_go_workflows:  
     if: startsWith(github.repository, 'asyncapi/')
@@ -58,14 +60,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/if-go-pr-testing.yml
           topics_to_include: golang
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update workflows for go projects"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_nodejs_workflows:
     if: startsWith(github.repository, 'asyncapi/')
@@ -75,14 +78,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/if-nodejs-pr-testing.yml
           topics_to_include: nodejs
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update workflows for nodejs projects"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_nodejs_release_workflows:
     if: startsWith(github.repository, 'asyncapi/')
@@ -92,14 +96,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/if-nodejs-release.yml,.github/workflows/if-nodejs-version-bump.yml,.github/workflows/bump.yml
           topics_to_include: get-global-node-release-workflows
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update release-related workflows for nodejs projects"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo
 
   # release config file must be managed separately
   # some projects may still use GH Action workflow for releases, but with different semantic-release config
@@ -111,14 +116,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/.releaserc
           topics_to_include: get-global-releaserc
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update semantic release config file"
+          commit_message: "ci: update of files from global .github repo"
+          destination: ./
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_generic_workflows:
     if: startsWith(github.repository, 'asyncapi/')
@@ -128,14 +135,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          patterns_to_include: .github/workflows/scripts,.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml,.github/workflows/add-good-first-issue-labels.yml,.github/workflows/automerge-for-humans-merging.yml,.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml,.github/workflows/automerge-orphans.yml,.github/workflows/automerge.yml,.github/workflows/autoupdate.yml,.github/workflows/help-command.yml,.github/workflows/issues-prs-notifications.yml,.github/workflows/lint-pr-title.yml,.github/workflows/notify-tsc-members-mention.yml,.github/workflows/sentiment-analysis.yml,.github/workflows/stale-issues-prs.yml,.github/workflows/welcome-first-time-contrib.yml,.github/workflows/release-announcements.yml,.github/workflows/link-check-cron.yml,.github/workflows/link-check-pr.yml
+          patterns_to_include: .github/workflows/scripts,.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml,.github/workflows/add-good-first-issue-labels.yml,.github/workflows/automerge-for-humans-merging.yml,.github/workflows/automerge-for-humans-remove-ready-to-merge-label-on-edit.yml,.github/workflows/automerge-orphans.yml,.github/workflows/automerge.yml,.github/workflows/autoupdate.yml,.github/workflows/help-command.yml,.github/workflows/issues-prs-notifications.yml,.github/workflows/lint-pr-title.yml,.github/workflows/notify-tsc-members-mention.yml,.github/workflows/stale-issues-prs.yml,.github/workflows/welcome-first-time-contrib.yml,.github/workflows/release-announcements.yml
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update generic workflows"
+          commit_message: "ci: update of files from global .github repo"
           repos_to_ignore: shape-up-process,glee-hello-world
+          bot_branch_name: bot/update-files-from-global-repo
 
   replicate_docker_workflows:
     if: startsWith(github.repository, 'asyncapi/')
@@ -145,11 +153,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Replicating file
-        uses: derberg/manage-files-in-multiple-repositories@54b11fb32004532b78afcb1fd64a06d37e7b6553
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           topics_to_include: docker
           patterns_to_include: .github/workflows/if-docker-pr-testing.yml
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          commit_message: "ci: update workflows for docker-based projects"
+          commit_message: "ci: update of files from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo


### PR DESCRIPTION
- new https://github.com/derberg/manage-files-in-multiple-repositories/releases/tag/v2.1.0
- new workflow that we can use specifically for removing files only
- update to have commit message always the same
- use static branch name, so one PR per repo and not `n` PR per repo depending how many jobs were triggered

all was driven by need to move a release config file from `.github/workflows` to root of repo that needs it