### PR TITLE
ci: skip workflows with new title and support skip for asyncapi-bot-eve

### DIFF
--- a/.github/workflows/if-docker-pr-testing.yml
+++ b/.github/workflows/if-docker-pr-testing.yml
@@ -14,20 +14,16 @@ jobs:
   test-docker-pr:
     name: Test Docker build
     runs-on: ubuntu-latest
-    
+
     steps:
       - if: >
           !github.event.pull_request.draft && !(
             (github.actor == 'asyncapi-bot' && (
-              startsWith(github.event.pull_request.title, 'ci: update global workflows') || 
-              startsWith(github.event.pull_request.title, 'chore: update code of conduct') || 
-              startsWith(github.event.pull_request.title, 'ci: update global contribution guide') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for go projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update release-related workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update semantic release config file') || 
-              startsWith(github.event.pull_request.title, 'ci: update generic workflows') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for docker-based projects') ||
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+              startsWith(github.event.pull_request.title, 'chore(release):')
+            )) ||
+            (github.actor == 'asyncapi-bot-eve' && (
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
               startsWith(github.event.pull_request.title, 'chore(release):')
             )) ||
             (github.actor == 'allcontributors[bot]' && 

--- a/.github/workflows/if-go-pr-testing.yml
+++ b/.github/workflows/if-go-pr-testing.yml
@@ -16,15 +16,11 @@ jobs:
       - if: >
           !github.event.pull_request.draft && !(
             (github.actor == 'asyncapi-bot' && (
-              startsWith(github.event.pull_request.title, 'ci: update global workflows') || 
-              startsWith(github.event.pull_request.title, 'chore: update code of conduct') || 
-              startsWith(github.event.pull_request.title, 'ci: update global contribution guide') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for go projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update release-related workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update semantic release config file') || 
-              startsWith(github.event.pull_request.title, 'ci: update generic workflows') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for docker-based projects') ||
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+              startsWith(github.event.pull_request.title, 'chore(release):')
+            )) ||
+            (github.actor == 'asyncapi-bot-eve' && (
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
               startsWith(github.event.pull_request.title, 'chore(release):')
             )) ||
             (github.actor == 'allcontributors[bot]' && 
@@ -64,15 +60,11 @@ jobs:
       - if: >
           !github.event.pull_request.draft && !(
             (github.actor == 'asyncapi-bot' && (
-              startsWith(github.event.pull_request.title, 'ci: update global workflows') || 
-              startsWith(github.event.pull_request.title, 'chore: update code of conduct') || 
-              startsWith(github.event.pull_request.title, 'ci: update global contribution guide') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for go projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update release-related workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update semantic release config file') || 
-              startsWith(github.event.pull_request.title, 'ci: update generic workflows') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for docker-based projects') ||
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+              startsWith(github.event.pull_request.title, 'chore(release):')
+            )) ||
+            (github.actor == 'asyncapi-bot-eve' && (
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
               startsWith(github.event.pull_request.title, 'chore(release):')
             )) ||
             (github.actor == 'allcontributors[bot]' && 

--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -19,15 +19,11 @@ jobs:
       - if: >
           !github.event.pull_request.draft && !(
             (github.actor == 'asyncapi-bot' && (
-              startsWith(github.event.pull_request.title, 'ci: update global workflows') || 
-              startsWith(github.event.pull_request.title, 'chore: update code of conduct') || 
-              startsWith(github.event.pull_request.title, 'ci: update global contribution guide') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for go projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update release-related workflows for nodejs projects') || 
-              startsWith(github.event.pull_request.title, 'ci: update semantic release config file') || 
-              startsWith(github.event.pull_request.title, 'ci: update generic workflows') || 
-              startsWith(github.event.pull_request.title, 'ci: update workflows for docker-based projects') ||
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+              startsWith(github.event.pull_request.title, 'chore(release):')
+            )) ||
+            (github.actor == 'asyncapi-bot-eve' && (
+              startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
               startsWith(github.event.pull_request.title, 'chore(release):')
             )) ||
             (github.actor == 'allcontributors[bot]' && 


### PR DESCRIPTION
- sometimes `asyncapi-bot-eve` autoupdates a PR and is last actor, so we need to also ignore it in some workflows
- use new pr title for global workflows