### PR TITLE
fix: added multiline strings to slack workflow

### DIFF
--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -32,7 +32,7 @@ runs:
           const slackifyMarkdown = require('slackify-markdown');
 
           try {
-              const md = `${{ inputs.markdown }}`;
+              const md = "${{ inputs.markdown }}";
               const mrkdwn = slackifyMarkdown(md);
               core.setOutput('text', mrkdwn);
           } catch (error) {

--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -32,8 +32,13 @@ runs:
           const slackifyMarkdown = require('slackify-markdown');
 
           try {
-              const md = "${{ inputs.markdown }}";
-              const mrkdwn = slackifyMarkdown(md);
+              const md = `${{ inputs.markdown }}`;
+              const splitLines = str => str.split(/\r?\n/);
+              let stringmd = ""
+              for (val of splitLines(md)){
+                stringmd += val + "\n \ "
+              }
+              const mrkdwn = slackifyMarkdown(stringmd);
               core.setOutput('text', mrkdwn);
           } catch (error) {
               core.setFailed(error.message);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR resolves the issue of `slackify-markdown` workflow by using multiline strings as input.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->