### PR TITLE
ci: fix slackify of markdown code

### DIFF
--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -27,18 +27,15 @@ runs:
     - name: Slackify
       uses: actions/github-script@v6
       id: slackify
+      env:
+        MARKDOWN: ${{ inputs.markdown }}
       with:
         script: |
           const slackifyMarkdown = require('slackify-markdown');
 
           try {
-              const md = `${{ inputs.markdown }}`;
-              const splitLines = str => str.split(/\r?\n/);
-              let stringmd = ""
-              for (val of splitLines(md)){
-                stringmd += val + "\n \ "
-              }
-              const mrkdwn = slackifyMarkdown(stringmd);
+              const md = process.env.MARKDOWN;
+              const mrkdwn = slackifyMarkdown(md);
               core.setOutput('text', mrkdwn);
           } catch (error) {
               core.setFailed(error.message);


### PR DESCRIPTION
- reverting changes from https://github.com/asyncapi/.github/pull/235/files?diff=split&w=0
- reading markdown input by passing it to environment variable first


Tested:
- slack action example https://github.com/derberg/test-experiment/blob/master/.github/actions/slackify-markdown/action.yml
- workflow example https://github.com/derberg/test-experiment/blob/master/.github/workflows/testtest.yml
- comment in issue example https://github.com/derberg/test-experiment/issues/150#issuecomment-1540116446
- run green example https://github.com/derberg/test-experiment/actions/runs/4926234621/jobs/8801502707

cc @akshatnema 

fixes https://github.com/asyncapi/.github/issues/231