### PR TITLE
ci: fix help command related to unexpected `{`

### DIFF
--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -27,13 +27,13 @@ jobs:
               repo: context.repo.repo,
               body: `Hello, @${{ github.actor }}! 👋🏼 
 
-                    I'm Genie from the magic lamp. Looks like somebody needs a hand! 🆘 
+                    I'm 🧞🧞🧞 Genie 🧞🧞🧞 from the magic lamp. Looks like somebody needs a hand!
         
                     At the moment the following comments are supported in pull requests:
         
-                    - `/ready-to-merge` or `/rtm` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
-                    - `/do-not-merge` or `/dnm` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
-                    - `/autoupdate` or `/au` - This comment will add `autoupdate` label to the PR and keeps your PR up-to-date to the target branch's future changes. Unless there is a merge conflict or it is a draft PR.`
+                    - \`/ready-to-merge\` or \`/rtm\` - This comment will trigger automerge of PR in case all required checks are green, approvals in place and do-not-merge label is not added
+                    - \`/do-not-merge\` or \`/dnm\` - This comment will block automerging even if all conditions are met and ready-to-merge label is added
+                    - \`/autoupdate\` or \`/au\` - This comment will add \`autoupdate\` label to the PR and keeps your PR up-to-date to the target branch's future changes. Unless there is a merge conflict or it is a draft PR.`
             })
 
   create_help_comment_issue:
@@ -51,10 +51,10 @@ jobs:
               repo: context.repo.repo,
               body: `Hello, @${{ github.actor }}! 👋🏼 
 
-              I'm Genie from the magic lamp. Looks like somebody needs a hand! 🆘 
+              I'm 🧞🧞🧞 Genie 🧞🧞🧞 from the magic lamp. Looks like somebody needs a hand!
   
               At the moment the following comments are supported in issues:
   
-              - `/good-first-issue {js | ts | java | go | docs | design | ci-cd} ` or `/gfi {js | ts | java | go | docs | design | ci-cd} ` - label an issue as a `good first issue`.
-              example: `/gfi js` or `/good-first-issue ci-cd`
+              - \`/good-first-issue {js | ts | java | go | docs | design | ci-cd}\` or \`/gfi {js | ts | java | go | docs | design | ci-cd}\` - label an issue as a \`good first issue\`.
+              example: \`/gfi js\` or \`/good-first-issue ci-cd\``
             })


### PR DESCRIPTION
during the migration of the command from using custom action, to using own js script, I forgot to make sure that markdown-related back-ticks should be escaped in code, otherwise JS fails with compilation

@KhudaDad414 once you approve please also just merge