### PR TITLE
docs: change `prefix` to `suffix` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Pull requests should have a title that follows the specification, otherwise, mer
 - `test: ` prefix in the title indicates that PR is only related to tests and there is no need to trigger release.
 - `refactor: ` prefix in the title indicates that PR is only related to refactoring and there is no need to trigger release.
 
-What about MAJOR release? just add `!` to the prefix, like `fix!: ` or `refactor!: `
+What about MAJOR release? just add `!` to the suffix after the specification, like `fix!: ` or `refactor!: `
 
 Prefix that follows specification is not enough though. Remember that the title must be clear and descriptive with usage of [imperative mood](https://chris.beams.io/posts/git-commit/#imperative).
 


### PR DESCRIPTION
**Description**

- Changed `prefix` to `suffix` as per grammatical rules.
- Added some more details to be more descriptive.
- Fixes #254

**Related issue(s)**
Fixes #254 