### PR TITLE
ci: enable block bot automerge with `do-not-merge`

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           GITHUB_LOGIN: asyncapi-bot
-          MERGE_LABELS: ""
+          MERGE_LABELS: "!do-not-merge"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
           MERGE_RETRIES: "20"


### PR DESCRIPTION
Sometimes you want to block merging of automated PR, not only of human PR

I wanted to do this in https://github.com/asyncapi/website/pull/2320 with `do-not-merge` label - but bot ignored me