### PR TITLE
fetat: add extensions-catalog to repos_to_ignore section of replicate_contri…

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CONTRIBUTING.md
-          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template
+          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template,extensions-catalog
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update of files from global .github repo"


### PR DESCRIPTION

**Description**
This PR is part of AsyncAPI Mentorship Program issue [#78](https://github.com/asyncapi/extensions-catalog/issues/78)
As extension catalog has its own contributing guide so there is no need of using this action for extension catalog repo

cc: @derberg 
