### PR TITLE
chore: add saunter to ignored repos list

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -31,4 +31,4 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
-          repos_to_ignore: spec,bindings
+          repos_to_ignore: spec,bindings,saunter

--- a/.github/workflows/global-remover.yml
+++ b/.github/workflows/global-remover.yml
@@ -49,5 +49,5 @@ jobs:
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update of files from global .github repo"
-          repos_to_ignore: shape-up-process,glee-hello-world
+          repos_to_ignore: shape-up-process,glee-hello-world,saunter
           bot_branch_name: bot/update-files-from-global-repo

--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CODE_OF_CONDUCT.md
-          repos_to_ignore: shape-up-process,glee-hello-world
+          repos_to_ignore: shape-up-process,glee-hello-world,saunter
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update of files from global .github repo"
@@ -46,7 +46,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: CONTRIBUTING.md
-          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template,extensions-catalog
+          repos_to_ignore: shape-up-process,glee-hello-world,spec,community,php-template,tck,modelina,dotnet-nats-template,ts-nats-template,extensions-catalog,saunter
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update of files from global .github repo"
@@ -142,7 +142,7 @@ jobs:
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update of files from global .github repo"
-          repos_to_ignore: shape-up-process,glee-hello-world
+          repos_to_ignore: shape-up-process,glee-hello-world,saunter
           bot_branch_name: bot/update-files-from-global-repo
 
   replicate_docker_workflows:


### PR DESCRIPTION
**Description**

Adds [saunter](https://github.com/asyncapi/saunter) to `repos_to_ignore` to prevent replication of workflow and bumping of packages.

**Related issue(s)**
Requested by @derberg in https://github.com/asyncapi/.github/pull/274#pullrequestreview-1928526340