### PR TITLE
ci: fix reinstallation of failure in release and pr testing

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -63,7 +63,7 @@ jobs:
         id: first-installation
         run: npm ci
         continue-on-error: true
-      - if: steps.first-installation.outputs.status == 'failure' && steps.packagejson.outputs.exists == 'true'
+      - if: steps.first-installation.outcome != 'success' && steps.packagejson.outputs.exists == 'true'
         name: Clear NPM cache and install deps again
         run: | 
           npm cache clean --force

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -102,7 +102,7 @@ jobs:
         id: first-installation
         run: npm ci
         continue-on-error: true
-      - if: steps.first-installation.outputs.status == 'failure' && steps.packagejson.outputs.exists == 'true'
+      - if: steps.first-installation.outcome != 'success' && steps.packagejson.outputs.exists == 'true'
         name: Clear NPM cache and install deps again
         run: | 
           npm cache clean --force


### PR DESCRIPTION
After the fix from yesterday I noticed that the reinstallation that we had in PR testing actually never worked as we used wrong keywords

we should use `outcome` as describe in https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context