### PR TITLE
ci: improve node testing and release

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -39,9 +39,10 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
+        shell: bash
       - if: steps.should_run.outputs.shouldrun == 'true' 
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - if: steps.should_run.outputs.shouldrun == 'true' 
         name: Check if Node.js project and has package.json
         id: packagejson
@@ -53,27 +54,26 @@ jobs:
         id: lockversion
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+      - if: steps.lockversion.outputs.version == '18' && matrix.os == 'windows-latest'
+        #npm cli 10 is buggy because of some cache issue
+        name: Install npm cli 8
+        shell: bash
+        run: npm install -g npm@8.19.4
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        id: first-installation
+        shell: bash
         run: npm ci
-        continue-on-error: true
-      - if: steps.first-installation.outcome != 'success' && steps.packagejson.outputs.exists == 'true'
-        name: Clear NPM cache and install deps again
-        run: | 
-          npm cache clean --force
-          npm ci
       - if: steps.packagejson.outputs.exists == 'true'
         name: Test
         run: npm test --if-present
-      - if: steps.packagejson.outputs.exists == 'true'
+      - if: steps.packagejson.outputs.exists == 'true' && matrix.os == 'ubuntu-latest'
+        #linting should run just one and not on all possible operating systems
         name: Run linter
         run: npm run lint --if-present
-      - if: steps.packagejson.outputs.exists == 'true'
+      - if: steps.packagejson.outputs.exists == 'true' && matrix.os == 'ubuntu-latest'
+        #checking assets generation is only needed on system that is later used in the bump workflow - so ubuntu
         name: Run release assets generation to make sure PR does not break it
         run: npm run generate:assets --if-present

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -38,8 +38,9 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
+        shell: bash
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
@@ -50,14 +51,18 @@ jobs:
         id: lockversion
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+      - if: steps.lockversion.outputs.version == '18' && matrix.os == 'windows-latest'
+        name: Install npm cli 8
+        shell: bash
+        #npm cli 10 is buggy because of some cache issues
+        run: npm install -g npm@8.19.4
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        run: npm install
+        shell: bash
+        run: npm ci
       - if: steps.packagejson.outputs.exists == 'true'
         name: Run test
         run: npm test --if-present
@@ -81,7 +86,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if Node.js project and has package.json
         id: packagejson
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
@@ -92,21 +97,13 @@ jobs:
         id: lockversion
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
-        id: first-installation
+        shell: bash
         run: npm ci
-        continue-on-error: true
-      - if: steps.first-installation.outcome != 'success' && steps.packagejson.outputs.exists == 'true'
-        name: Clear NPM cache and install deps again
-        run: | 
-          npm cache clean --force
-          npm ci
       - if: steps.packagejson.outputs.exists == 'true'
         name: Add plugin for conventional commits for semantic-release
         run: npm install --save-dev conventional-changelog-conventionalcommits@5.0.0


### PR DESCRIPTION
- changes to PR testing were battle-tested in https://github.com/asyncapi/cli/pull/1340 first
  - we had to apply workaround for npm version on windows
  - now we have a bit faster workflow as linting and assets gen is done on ubuntu only 
- changes to release workflow were battle-tested after merging https://github.com/asyncapi/cli/pull/1338 and seeing release passed without issues https://github.com/asyncapi/cli/actions/runs/8614265053 and we have new release https://github.com/asyncapi/cli/releases/tag/v1.8.0