### PR TITLE
ci: use latest bumping action feature to reuse PRs

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,9 +26,10 @@ jobs:
         run: test -e ./package.json && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
       - if: steps.packagejson.outputs.exists == 'true'
         name: Bumping latest version of this package in other repositories
-        uses: derberg/npm-dependency-manager-for-your-github-org@3df56be95bcaa5c76a9c9a4af863ab151545b649 # using v6.-.- https://github.com/derberg/npm-dependency-manager-for-your-github-org/releases/tag/v6
+        uses: derberg/npm-dependency-manager-for-your-github-org@1eafd3bf3974f21d395c1abac855cb04b295d570 # using v6.-.- https://github.com/derberg/npm-dependency-manager-for-your-github-org/releases/tag/v6
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           repos_to_ignore: spec,bindings,saunter
+          custom_id: "dependency update from asyncapi bot"


### PR DESCRIPTION
Have you ever seen below

![Screenshot 2024-04-09 at 13 30 25](https://github.com/asyncapi/.github/assets/6995927/64f84aa0-fa48-4932-b0cf-da3901c378b1)

- I'm just personally tired cleaning up CI on daily basis - that is too much
- This is a terrible waste of resources, like big time

This PR uses my latest action that basically reuses existing PRs, but only if they have a custom id marker in it (basically hidden comment in PR description)

Here you see an example that was once created by bump workflow, and then again it was updated with never version of the dependency, without creating new PR -> https://github.com/lukasz-lab/nie-niet-none/pull/48
