### PR TITLE
ci: add support for `next` release branch

### DIFF
--- a/.github/workflows/.releaserc
+++ b/.github/workflows/.releaserc
@@ -13,6 +13,8 @@ branches:
   prerelease: true
 - name: alpha
   prerelease: true
+- name: next
+  prerelease: true
 plugins:
 - - "@semantic-release/commit-analyzer"
   - preset: conventionalcommits

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -15,6 +15,7 @@ on:
       - next-major-spec
       - beta
       - alpha
+      - next
 
 jobs:
 


### PR DESCRIPTION
**Description**
In Modelina we have been using `next` since the beginning, however, we decided to remove it from the official workflow 🤨 We did a patch at some point in Modelina, and then I forgot about it.

This PR adds it officially.