### PR TITLE
ci: trigger MAINTAINERS.yaml update for each CODEOWNERS file change

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -217,6 +217,8 @@ jobs:
           commit_message: "ci: update .prettierignore from global .github repo"
           bot_branch_name: bot/update-files-from-global-repo
 
+  # This setup is separate from the generic workflow setup because this workflow is mandatory. 
+  # Maintainers cannot opt out for any reason except technical ones.
   replicate_update_maintainers_workflow:
     if: startsWith(github.repository, 'asyncapi/')
     name: Replicate update-maintainers-trigger.yml workflow in the required repositories

--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -229,7 +229,7 @@ jobs:
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           patterns_to_include: .github/workflows/update-maintainers-trigger.yml
-          repos_to_ignore: community,shape-up-process
+          repos_to_ignore: community,shape-up-process # community repo is ignored as it has its own version of this workflow, version that is triggered by this workflow
           committer_username: asyncapi-bot
           committer_email: info@asyncapi.io
           commit_message: "ci: update update-maintainers-trigger.yml workflow from global .github repo"

--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -216,3 +216,21 @@ jobs:
           committer_email: info@asyncapi.io
           commit_message: "ci: update .prettierignore from global .github repo"
           bot_branch_name: bot/update-files-from-global-repo
+
+  replicate_update_maintainers_workflow:
+    if: startsWith(github.repository, 'asyncapi/')
+    name: Replicate update-maintainers-trigger.yml workflow in the required repositories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Replicating file
+        uses: derberg/manage-files-in-multiple-repositories@beecbe897cf5ed7f3de5a791a3f2d70102fe7c25
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          patterns_to_include: .github/workflows/update-maintainers-trigger.yml
+          repos_to_ignore: community,shape-up-process
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          commit_message: "ci: update update-maintainers-trigger.yml workflow from global .github repo"
+          bot_branch_name: bot/update-files-from-global-repo

--- a/.github/workflows/update-maintainers-trigger.yaml
+++ b/.github/workflows/update-maintainers-trigger.yaml
@@ -1,0 +1,27 @@
+# This action is centrally managed in https://github.com/asyncapi/.github/
+# Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in above mentioned repo
+
+name: Trigger MAINTAINERS.yaml file update
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      # Check all valid CODEOWNERS locations: 
+      # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location
+      - 'CODEOWNERS'
+      - '.github/CODEOWNERS'
+      - '.docs/CODEOWNERS'
+
+jobs:
+  trigger-maintainers-update:
+    name: Trigger updating MAINTAINERS.yaml because of CODEOWNERS change
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # https://github.com/peter-evans/repository-dispatch/releases/tag/v3.0.0
+        with:
+          # The PAT with the 'public_repo' scope is required
+          token: ${{ secrets.GH_TOKEN }}
+          event-type: trigger-maintainers-update

--- a/.github/workflows/update-maintainers-trigger.yaml
+++ b/.github/workflows/update-maintainers-trigger.yaml
@@ -24,4 +24,5 @@ jobs:
         with:
           # The PAT with the 'public_repo' scope is required
           token: ${{ secrets.GH_TOKEN }}
+          repository: ${{ github.repository_owner }}/community
           event-type: trigger-maintainers-update


### PR DESCRIPTION
**Description**

- This PR provides a generic workflow that triggers the "MAINTAINERS.yaml" file update in `community` repository

The main logic is defined in the `community` repo, see: https://github.com/asyncapi/community/pull/1315

**Related issue(s)**

Blocked by: https://github.com/asyncapi/community/pull/1314 and https://github.com/asyncapi/github-action-for-cli/pull/397

Fix: https://github.com/asyncapi/community/issues/1269