### PR TITLE
docs: fix link to specification reference docs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -35,7 +35,7 @@ Are you wondering where to look first? Then search no more! Here are some great 
 
 - [Intro to AsyncAPI](https://www.asyncapi.com/docs/getting-started) 🔮
 - [Tutorials](https://www.asyncapi.com/docs/tutorials) 📚
-- [Spec Details](https://www.asyncapi.com/docs/specifications/latest) 🔍
+- [Spec Details](https://www.asyncapi.com/docs/reference/specification/latest) 🔍
 - [Tools](https://www.asyncapi.com/docs/community/tooling) 🛠️
 
 ## 👩🏽‍💻 Contribute to AsyncAPI


### PR DESCRIPTION
**Description**

Fixed broken link to the latest specification in the organization profile:

Before | After 
-------|------
<img width="614" alt="Screenshot 2024-09-27 at 9 50 27 PM" src="https://github.com/user-attachments/assets/ae6add87-5a50-4064-ba5a-1f3a9a924e97"> | <img width="583" alt="Screenshot 2024-09-27 at 9 51 44 PM" src="https://github.com/user-attachments/assets/5e7cd9e5-a279-4563-8560-dd2a5beb4693">
