### PR TITLE
fix: add destination for .prettierignore replication

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -216,6 +216,7 @@ jobs:
           committer_email: info@asyncapi.io
           commit_message: "ci: update .prettierignore from global .github repo"
           bot_branch_name: bot/update-files-from-global-repo
+          destination: ./ 
 
   # This setup is separate from the generic workflow setup because this workflow is mandatory. 
   # Maintainers cannot opt out for any reason except technical ones.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:  
1. Follow our contribution guidelines  
2. Test your changes and attach their results to the pull request.  
3. Update the relevant documentation.  
-->

**Description**

- Added the `destination` property to the `replicate_prettierignore_file` step in the `.github/workflows/global-replicator.yml` workflow.
- This ensures that the `.prettierignore` file is replicated correctly in the repository's root directory (`./`).

**Related issue(s)**

- Fixes #316
