### PR TITLE
ci: install slackify globally to avoid conflicts with pnpm

### DIFF
--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -21,7 +21,7 @@ runs:
         node-version: 16
     - name: Install slackify-markdown package
       shell: bash
-      run: npm install slackify-markdown@4.3.1
+      run: npm install -g slackify-markdown@4.3.1
     - name: Slackify
       uses: actions/github-script@v6
       id: slackify


### PR DESCRIPTION
### Description

Some repos like studio and glee are using pnpm. Pnpm uses a syntax in the package.json file that npm doesn't recognize as valid, namely `"package-name": "workspace:*"`. The Slackify action in this repo tries to install a dependency on the repo using npm and that causes an error: https://github.com/asyncapi/glee/actions/runs/11571817568/job/32210507703.

To avoid this problem, I'd advocate for simply installing the dependency globally instead.