### PR TITLE
fix: global installs do not work as I expected

### DIFF
--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -19,9 +19,17 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+    - name: Create and initialize slackify directory
+      shell: bash
+      run: | # We need to create a directory to install the slackify-markdown package to avoid conflicting with repositories using pnpm.
+        mkdir slackify
+        cd slackify
+        npm init -y
     - name: Install slackify-markdown package
       shell: bash
-      run: npm install -g slackify-markdown@4.3.1
+      run: |
+        cd slackify
+        npm install slackify-markdown@4.3.1
     - name: Slackify
       uses: actions/github-script@v6
       id: slackify
@@ -29,7 +37,7 @@ runs:
         MARKDOWN: ${{ inputs.markdown }}
       with:
         script: |
-          const slackifyMarkdown = require('slackify-markdown');
+          const slackifyMarkdown = require('./slackify/node_modules/slackify-markdown');
 
           try {
               const md = process.env.MARKDOWN;

--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -46,3 +46,8 @@ runs:
           } catch (error) {
               core.setFailed(error.message);
           }
+    - name: Clean up slackify directory
+      shell: bash
+      run: |
+        cd ..
+        rm -rf slackify

--- a/.github/actions/slackify-markdown/action.yml
+++ b/.github/actions/slackify-markdown/action.yml
@@ -27,17 +27,18 @@ runs:
         npm init -y
     - name: Install slackify-markdown package
       shell: bash
+      working-directory: slackify
       run: |
-        cd slackify
         npm install slackify-markdown@4.3.1
     - name: Slackify
       uses: actions/github-script@v6
       id: slackify
+      working-directory: slackify
       env:
         MARKDOWN: ${{ inputs.markdown }}
       with:
         script: |
-          const slackifyMarkdown = require('./slackify/node_modules/slackify-markdown');
+          const slackifyMarkdown = require('slackify-markdown');
 
           try {
               const md = process.env.MARKDOWN;
@@ -49,5 +50,4 @@ runs:
     - name: Clean up slackify directory
       shell: bash
       run: |
-        cd ..
         rm -rf slackify


### PR DESCRIPTION
### Description

Fixes a problem introduced in #318. Global installs are not available when running "require()" in a script.

As a workaround, I'm creating a new directory with its own package.json file just to run this action. This way, npm won't complain. I checked locally and it worked.