### PR TITLE
fix: update token for gh command

### DIFF
--- a/.github/workflows/transfer-issue.yml
+++ b/.github/workflows/transfer-issue.yml
@@ -8,9 +8,6 @@ on:
     types:
       - created
 
-permissions:
-  issues: write
-  
 jobs:
   transfer:
     if: ${{(!github.event.issue.pull_request && github.event.issue.state != 'closed' && github.actor != 'asyncapi-bot') && (startsWith(github.event.comment.body, '/transfer-issue') || startsWith(github.event.comment.body, '/ti'))}}
@@ -57,5 +54,5 @@ jobs:
         run: |
           gh issue transfer ${{github.event.issue.number}} asyncapi/${{steps.extract_step.outputs.repo}}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRANSFER_ISSUE_TOKEN }}
           


### PR DESCRIPTION
Since `transfer` command was not working as intended because of some permission issue. After googling a bit looks like it needs a token which has write access to both the repository for it to be able to transfer the issue. So before this PR is merged a token with correct access needs to be added. 

Name of the token: `TRANSFER_ISSUE_TOKEN`