### PR TITLE
ci: fix tsc notification workflow for sending email

### DIFF
--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -66,11 +66,11 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.issue.title}}
+          TITLE: ${{ github.event.issue.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.issue.html_url}}', '$TITLE');
+            sendEmail('${{github.event.issue.html_url}}', process.env.TITLE);
 
   pull_request:
     if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@asyncapi/tsc_members')
@@ -112,11 +112,11 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.pull_request.title}}
+          TITLE: ${{ github.event.pull_request.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.pull_request.html_url}}', '$TITLE');
+            sendEmail('${{github.event.pull_request.html_url}}', process.env.TITLE);
 
   discussion:
     if: github.event_name == 'discussion' && contains(github.event.discussion.body, '@asyncapi/tsc_members')
@@ -158,11 +158,11 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.discussion.title}}
+          TITLE: ${{ github.event.discussion.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.discussion.html_url}}', '$TITLE');
+            sendEmail('${{github.event.discussion.html_url}}', process.env.TITLE);
 
   issue_comment:
     if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members') }}
@@ -204,11 +204,11 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.issue.title}}
+          TITLE: ${{ github.event.issue.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}', '$TITLE');
+            sendEmail('${{github.event.comment.html_url}}', process.env.TITLE);
 
   pr_comment:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@asyncapi/tsc_members')
@@ -250,11 +250,11 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.issue.title}}
+          TITLE: ${{ github.event.issue.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}', '$TITLE');
+            sendEmail('${{github.event.comment.html_url}}', process.env.TITLE);
 
   discussion_comment:
     if: github.event_name == 'discussion_comment' && contains(github.event.comment.body, '@asyncapi/tsc_members')
@@ -296,8 +296,8 @@ jobs:
           CALENDAR_ID: ${{ secrets.CALENDAR_ID }}
           CALENDAR_SERVICE_ACCOUNT: ${{ secrets.CALENDAR_SERVICE_ACCOUNT }}
           MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
-          TITLE: ${{github.event.discussion.title}}
+          TITLE: ${{ github.event.discussion.title }}
         with:
           script: |
             const sendEmail = require('./.github/workflows/scripts/mailchimp/index.js');
-            sendEmail('${{github.event.comment.html_url}}', '$TITLE');
+            sendEmail('${{github.event.comment.html_url}}', process.env.TITLE);


### PR DESCRIPTION
errors shows by coderabbit in https://github.com/asyncapi/website/pull/4266 were true, title is now not properly propagated to the send email function as `$TITLE`

<img width="610" height="401" alt="Screenshot 2025-07-28 at 12 54 52" src="https://github.com/user-attachments/assets/7339b6ff-2364-4283-bccd-1bca1ad41223" />
