### PR TITLE
ci: use new bump action version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -37,4 +37,4 @@ jobs:
           repos_to_ignore: spec,bindings,saunter,server-api
           custom_id: "dependency update from asyncapi bot"
           search: "true"
-          ignore_paths: ./github/workflows
+          ignore_paths: .github/workflows


### PR DESCRIPTION
**Description**

- Support for mono-repos have been rolled out with https://github.com/derberg/npm-dependency-manager-for-your-github-org/pull/17.

**Related issue(s)**
Fixes https://github.com/asyncapi/studio/issues/1161