### PR TITLE
fix: fix macOS GitHub action version

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
       - if: >
           !github.event.pull_request.draft && !(


### PR DESCRIPTION
The website GitHub actions were failing because of 'macOS-latest' 
We need to change it to macOS-15 version