### PR TITLE
ci: make sure action to determine node version installs globally

### DIFF
--- a/.github/actions/get-node-version-from-package-lock/action.yml
+++ b/.github/actions/get-node-version-from-package-lock/action.yml
@@ -13,10 +13,10 @@ runs:
   steps:
     - name: Install semver package
       shell: bash
-      run: npm install --no-save semver@7.7.3
+      run: npm install -g semver@7.7.3
       
     - name: Get Node version
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       id: getnode
       env:
         # Map the composite action input to an environment variable for the script


### PR DESCRIPTION
semver must be installed globally otherwise this action is sensible to engine requirements of given project

for example this action runs on default node 20 and generator needs 24, so semver installation in project, instead of globally fails