### PR TITLE
ci: update release pipeline

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -120,7 +120,7 @@ jobs:
         run: npm ci
       - if: steps.packagejson.outputs.exists == 'true'
         name: Add plugin for conventional commits for semantic-release
-        run: npm install --save-dev conventional-changelog-conventionalcommits@5.0.0
+        run: npm install --save-dev conventional-changelog-conventionalcommits@9.1.0
       - if: steps.packagejson.outputs.exists == 'true'
         name: Publish to any of NPM, Github, and Docker Hub
         id: release


### PR DESCRIPTION
at the moment releases follow angular standard for conventional commits so `!` as major is not understood by the pipeline.

related https://github.com/asyncapi/markdown-template/pull/655