### PR TITLE
chore: change slack etiquette url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,7 +22,7 @@ To get involved with our community, please make sure you are familiar with the p
 
 We're a community of great people who are passionate about AsyncAPI and Event-Driven Architectures. There are several ways to communicate with other people working on the AsyncAPI project:
 
-- **Join our Slack workspace**: [Join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️ and please respect [our slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md). If you have a question on how to use AsyncAPI, want to contribute, or simply want to say hello 👋🏾, feel free to chat with us in Slack. We're nice people. 🙂
+- **Join our Slack workspace**: [Join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️ and please respect [our slack etiquette](https://www.asyncapi.com/docs/community/060-meetings-and-communication/slack-etiquette). If you have a question on how to use AsyncAPI, want to contribute, or simply want to say hello 👋🏾, feel free to chat with us in Slack. We're nice people. 🙂
 - **Join our public meetings**: AsyncAPI hosts different meetings every week. They are focused on different topic, sometimes purely technical and sometimes about community building. Pick one and join us! [Learn more about our meetings](https://www.asyncapi.com/community/events).
 - **Subscribe to our [Newsletter](https://www.asyncapi.com/newsletter)**: keep up to date on the project's status.
 - **GitHub issues**: for bugs and feature requests.


### PR DESCRIPTION
Changed the Slack etiquette url to https://www.asyncapi.com/docs/community/060-meetings-and-communication/slack-etiquette in /profile/readme.md and CONTRIBUTING.md

Fixes #339