### PR TITLE
chore: fix broken slack etiquette url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,7 +22,7 @@ To get involved with our community, please make sure you are familiar with the p
 
 We're a community of great people who are passionate about AsyncAPI and Event-Driven Architectures. There are several ways to communicate with other people working on the AsyncAPI project:
 
-- **Join our Slack workspace**: [Join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️ and please respect [our slack etiquette](https://github.com/asyncapi/community/blob/master/slack-etiquette.md). If you have a question on how to use AsyncAPI, want to contribute, or simply want to say hello 👋🏾, feel free to chat with us in Slack. We're nice people. 🙂
+- **Join our Slack workspace**: [Join our Slack workspace](https://www.asyncapi.com/slack-invite) ☎️ and please respect [our slack etiquette](https://github.com/asyncapi/.github/blob/master/slack-etiquette.md). If you have a question on how to use AsyncAPI, want to contribute, or simply want to say hello 👋🏾, feel free to chat with us in Slack. We're nice people. 🙂
 - **Join our public meetings**: AsyncAPI hosts different meetings every week. They are focused on different topic, sometimes purely technical and sometimes about community building. Pick one and join us! [Learn more about our meetings](https://www.asyncapi.com/community/events).
 - **Subscribe to our [Newsletter](https://www.asyncapi.com/newsletter)**: keep up to date on the project's status.
 - **GitHub issues**: for bugs and feature requests.


### PR DESCRIPTION
### Description
Fixed the broken Slack Etiquette link by updating it to the correct and current AsyncAPI documentation URL.

### Changes
- Updated Slack Etiquette link in:
  - `.github/profile/README.md`
  - `.github/CONTRIBUTING.md`

### Related Issue
Closes #339
