### PR TITLE
fix: update transfer-issue.yml

### DIFF
--- a/.github/workflows/transfer-issue.yml
+++ b/.github/workflows/transfer-issue.yml
@@ -57,6 +57,6 @@ jobs:
         run: |
           gh issue transfer "$ISSUE_NUMBER" "asyncapi/$REPO_NAME"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO_NAME: ${{ steps.extract_step.outputs.repo }}


### PR DESCRIPTION
**Description**

Addresses `/ti` command permission errors by using `secrets.GH_TOKEN` instead of `secrets.GITHUB_TOKEN` (limited to current repo only).

Issue: #344 
