### PR TITLE
fix: prevent conflicting required options in design issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design.yml
+++ b/.github/ISSUE_TEMPLATE/design.yml
@@ -69,14 +69,11 @@ body:
         - label: I have reviewed the [Contributing Guidelines](https://github.com/asyncapi/.github/blob/master/CONTRIBUTING.md).
           required: true
 
-  - type: checkboxes
+  - type: dropdown
     id: help-fixing
     attributes:
       label: Are you willing to work on this issue?
       description: This is absolutely not required, but we are happy to guide you in the contribution process.
-      label: Would you like to help fix this issue? (Not required, but appreciated!)
       options:
-        - label: Yes, I am interested in contributing to the fix.
-          required: true
-        - label: No, I am just reporting the issue.
-          required: true
+        - "Yes I am willing to submit a PR!"
+        - "No, someone else can work on it"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Fixes an issue in the Design Issue Report template where users were forced to select both “Yes” and “No” when indicating whether they want to help fix the issue. This was caused by mutually exclusive checkboxes being marked as required and a duplicate label definition.

Closes #380

### Changes
- Removed the duplicate `label` definition
- Replaced required checkboxes with a dropdown to enforce a single choice
- Aligns behavior with the Bug Report template

### Result
The issue form no longer blocks submission and provides a clearer contributor experience.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->