### PR TITLE
feat: harden workflow validation and permissions

### DIFF
--- a/.github/workflows/add-good-first-issue-labels.yml
+++ b/.github/workflows/add-good-first-issue-labels.yml
@@ -9,6 +9,9 @@ on:
     types:
       - created
 
+permissions:
+  issues: write
+
 jobs:
   add-labels:
     if: ${{(!github.event.issue.pull_request && github.event.issue.state != 'closed' && github.actor != 'asyncapi-bot') && (contains(github.event.comment.body, '/good-first-issue') || contains(github.event.comment.body, '/gfi' ))}}

--- a/.github/workflows/bounty-program-commands.yml
+++ b/.github/workflows/bounty-program-commands.yml
@@ -14,6 +14,9 @@ on:
     types:
       - created
 
+permissions:
+  issues: write
+
 env:
   BOUNTY_PROGRAM_LABELS_JSON: |
     [

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -8,6 +8,10 @@ on:
         types: 
             - created
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   create_help_comment_pr:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/help') && github.actor != 'asyncapi-bot' }}

--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -14,6 +14,9 @@ on:
   discussion:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   issue:
     if: github.event_name == 'issues' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, edited, ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   lint-pr-title:
     name: Lint PR title

--- a/.github/workflows/notify-tsc-members-mention.yml
+++ b/.github/workflows/notify-tsc-members-mention.yml
@@ -25,6 +25,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   issue:
     if: github.event_name == 'issues' && contains(github.event.issue.body, '@asyncapi/tsc_members')

--- a/.github/workflows/validate-workflow-schema.yml
+++ b/.github/workflows/validate-workflow-schema.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '.github/workflows/**'
 
+permissions:
+  contents: read
+
 jobs:
   yaml-lint:
     runs-on: ubuntu-latest
@@ -70,3 +73,18 @@ jobs:
               }
             }
             validateWorkflows();
+
+  workflow-security:
+    name: Workflow security checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.1.2
+        with:
+          persona: pedantic

--- a/.github/workflows/welcome-first-time-contrib.yml
+++ b/.github/workflows/welcome-first-time-contrib.yml
@@ -11,6 +11,10 @@ on:
     types:
       - opened
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   welcome:
     name: Post welcome message


### PR DESCRIPTION
Fixes #388

This expands the workflow-validation path instead of only patching a few individual workflows:
- add a unified workflow security job on top of the existing schema check
- run `actionlint` and `zizmor` in CI for workflow changes
- add explicit least-privilege `permissions` to the highest-risk `pull_request_target` and `issue_comment` workflows
- keep the scope small enough to review independently from the broader workflow cleanup already in progress

Validated locally by parsing all workflow YAML files after the changes.