### PR TITLE
ci: need to use GH_TOKEN for labeling

### DIFF
--- a/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
+++ b/.github/workflows/automerge-for-humans-add-ready-to-merge-or-do-not-merge-label.yml
@@ -37,7 +37,10 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
         with:
-          github-token: ${{ github.token }}
+          # Use bot PAT, not the default GITHUB_TOKEN: events created by
+          # GITHUB_TOKEN do not trigger other workflows, so `Automerge For
+          # Humans` would never see the `labeled` event.
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             const prDetailsUrl = context.payload.issue.pull_request.url;
             const { data: pull } = await github.request(prDetailsUrl);
@@ -93,7 +96,8 @@ jobs:
       - name: Add do-not-merge label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          # Bot PAT so the `labeled` event can trigger downstream workflows.
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,
@@ -119,7 +123,8 @@ jobs:
       - name: Add autoupdate label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          # Bot PAT so the `labeled` event can trigger the autoupdate workflow.
+          github-token: ${{ secrets.GH_TOKEN }}
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- GITHUB_TOKEN adding labels cannot trigger new workflows. Leading to a little broken merging pipeline.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->