### PR TITLE
ci: add 'per_page' query parameter to Microgrant Program workflow

### DIFF
--- a/.github/workflows/microgrant-program-commands.yml
+++ b/.github/workflows/microgrant-program-commands.yml
@@ -78,6 +78,7 @@ jobs:
             let LIST_OF_LABELS_FOR_REPO = await github.rest.issues.listLabelsForRepo({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                per_page: 100,
                 });
                 
             LIST_OF_LABELS_FOR_REPO = LIST_OF_LABELS_FOR_REPO.data.map(key => key.name);


### PR DESCRIPTION
This PR adds `per_page` query parameter to the REST API request for listing all labels in a repository, because the `microgrant` label typically appears beyond the [default range](https://docs.github.com/en/rest/issues/labels?apiVersion=2026-03-10#list-labels-for-an-issue) of `30`, causing the `microgrant-program-commands.yml` GitHub Actions workflow to [fail](https://github.com/asyncapi/website/actions/runs/26484345357/job/77988408648).